### PR TITLE
Modify cache strategy in glide.

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/FolderPickerAdapter.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/FolderPickerAdapter.java
@@ -44,7 +44,7 @@ public class FolderPickerAdapter extends RecyclerView.Adapter<FolderPickerAdapte
         final Folder folder = folders.get(position);
 
         Glide.with(context)
-                .load(folder.getImages().get(0).getPath())
+                .load(folder.getImages().get(0).getPath()).diskCacheStrategy(DiskCacheStrategy.SOURCE)
                 .placeholder(R.drawable.folder_placeholder)
                 .error(R.drawable.folder_placeholder)
                 .into(holder.image);

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/ImagePickerAdapter.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/ImagePickerAdapter.java
@@ -45,7 +45,7 @@ public class ImagePickerAdapter extends RecyclerView.Adapter<ImagePickerAdapter.
         Image image = images.get(position);
 
         Glide.with(context)
-                .load(image.getPath())
+                .load(image.getPath()).diskCacheStrategy(DiskCacheStrategy.SOURCE)
                 .placeholder(R.drawable.image_placeholder)
                 .error(R.drawable.image_placeholder)
                 .into(viewHolder.imageView);


### PR DESCRIPTION
Default disk cache strategy is too late for gif format.
DiskCacheStrategy.SOURCE is faster than before.