### PR TITLE
Expose config

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePicker.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePicker.java
@@ -138,6 +138,10 @@ public abstract class ImagePicker {
         return this;
     }
 
+    protected ImagePickerConfig getConfig() {
+        return config;
+    }
+
     public ImagePicker enableLog(boolean isEnable) {
         IpLogger.getInstance().setEnable(isEnable);
         return this;


### PR DESCRIPTION
In the need of trying to use a custom `ImagePickerActivity` (or an extension) I would like to be able to override `ImagePicker#getIntent()` and access my current config to launch the activity.

The getter is for general purpose.