### PR TITLE
Added option to exclude files from being display

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImageFileLoader.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImageFileLoader.java
@@ -32,8 +32,8 @@ public class ImageFileLoader {
             MediaStore.Images.Media.BUCKET_DISPLAY_NAME
     };
 
-    public void loadDeviceImages(final boolean isFolderMode, final ImageLoaderListener listener) {
-        getExecutorService().execute(new ImageLoadRunnable(isFolderMode, listener));
+    public void loadDeviceImages(final boolean isFolderMode, final ArrayList<File> excludedImages, final ImageLoaderListener listener) {
+        getExecutorService().execute(new ImageLoadRunnable(isFolderMode, excludedImages, listener));
     }
 
     public void abortLoadImages() {
@@ -53,10 +53,12 @@ public class ImageFileLoader {
     private class ImageLoadRunnable implements Runnable {
 
         private boolean isFolderMode;
+        private ArrayList<File> exlucedImages;
         private ImageLoaderListener listener;
 
-        public ImageLoadRunnable(boolean isFolderMode, ImageLoaderListener listener) {
+        public ImageLoadRunnable(boolean isFolderMode, ArrayList<File> excludedImages, ImageLoaderListener listener) {
             this.isFolderMode = isFolderMode;
+            this.exlucedImages = excludedImages;
             this.listener = listener;
         }
 
@@ -70,7 +72,7 @@ public class ImageFileLoader {
                 return;
             }
 
-            List<Image> temp = new ArrayList<>(cursor.getCount());
+            List<Image> temp = new ArrayList<>();
             Map<String, Folder> folderMap = null;
             if (isFolderMode) {
                 folderMap = new HashMap<>();
@@ -85,6 +87,9 @@ public class ImageFileLoader {
 
                     File file = makeSafeFile(path);
                     if (file != null && file.exists()) {
+                        if(exlucedImages != null && exlucedImages.contains(file))
+                            continue;
+
                         Image image = new Image(id, name, path);
                         temp.add(image);
 

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePicker.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePicker.java
@@ -12,6 +12,7 @@ import com.esafirm.imagepicker.helper.ConfigUtils;
 import com.esafirm.imagepicker.helper.IpLogger;
 import com.esafirm.imagepicker.model.Image;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -121,6 +122,16 @@ public abstract class ImagePicker {
 
     public ImagePicker origin(ArrayList<Image> images) {
         config.setSelectedImages(images);
+        return this;
+    }
+
+    public ImagePicker exclude(ArrayList<Image> images) {
+        config.setExcludedImages(images);
+        return this;
+    }
+
+    public ImagePicker excludeFiles(ArrayList<File> files) {
+        config.setExcludedImageFiles(files);
         return this;
     }
 

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.java
@@ -277,7 +277,7 @@ public class ImagePickerActivity extends AppCompatActivity implements ImagePicke
 
     private void getData() {
         presenter.abortLoad();
-        presenter.loadImages(config.isFolderMode());
+        presenter.loadImages(config.isFolderMode(), config.getExcludedImages());
     }
 
     /**

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.java
@@ -8,7 +8,7 @@ import com.esafirm.imagepicker.features.common.BaseConfig;
 import com.esafirm.imagepicker.features.imageloader.ImageLoader;
 import com.esafirm.imagepicker.model.Image;
 
-import java.io.*;
+import java.io.File;
 import java.util.ArrayList;
 
 public class ImagePickerConfig extends BaseConfig implements Parcelable {
@@ -84,12 +84,10 @@ public class ImagePickerConfig extends BaseConfig implements Parcelable {
     }
 
     public void setExcludedImages(ArrayList<Image> excludedImages) {
-        if(excludedImages == null)
-        {
-            this.excludedImages = null;
-        } else {
-            for(Image image : excludedImages)
+        if(excludedImages != null && !excludedImages.isEmpty()) {
+            for (Image image : excludedImages) {
                 this.excludedImages.add(new File(image.getPath()));
+            }
         }
     }
 
@@ -134,6 +132,7 @@ public class ImagePickerConfig extends BaseConfig implements Parcelable {
     public void writeToParcel(Parcel dest, int flags) {
         super.writeToParcel(dest, flags);
         dest.writeTypedList(this.selectedImages);
+        dest.writeList(this.excludedImages);
         dest.writeString(this.folderTitle);
         dest.writeString(this.imageTitle);
         dest.writeInt(this.mode);
@@ -147,6 +146,7 @@ public class ImagePickerConfig extends BaseConfig implements Parcelable {
     protected ImagePickerConfig(Parcel in) {
         super(in);
         this.selectedImages = in.createTypedArrayList(Image.CREATOR);
+        in.readList(this.excludedImages, File.class.getClassLoader());
         this.folderTitle = in.readString();
         this.imageTitle = in.readString();
         this.mode = in.readInt();

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.java
@@ -8,11 +8,13 @@ import com.esafirm.imagepicker.features.common.BaseConfig;
 import com.esafirm.imagepicker.features.imageloader.ImageLoader;
 import com.esafirm.imagepicker.model.Image;
 
+import java.io.*;
 import java.util.ArrayList;
 
 public class ImagePickerConfig extends BaseConfig implements Parcelable {
 
     private ArrayList<Image> selectedImages;
+    private ArrayList<File> excludedImages;
 
     private String folderTitle;
     private String imageTitle;
@@ -75,6 +77,24 @@ public class ImagePickerConfig extends BaseConfig implements Parcelable {
 
     public void setSelectedImages(ArrayList<Image> selectedImages) {
         this.selectedImages = selectedImages;
+    }
+
+    public ArrayList<File> getExcludedImages() {
+        return excludedImages;
+    }
+
+    public void setExcludedImages(ArrayList<Image> excludedImages) {
+        if(excludedImages == null)
+        {
+            this.excludedImages = null;
+        } else {
+            for(Image image : excludedImages)
+                this.excludedImages.add(new File(image.getPath()));
+        }
+    }
+
+    public void setExcludedImageFiles(ArrayList<File> excludedImages) {
+        this.excludedImages = excludedImages;
     }
 
     public boolean isFolderMode() {

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.java
@@ -16,6 +16,7 @@ import com.esafirm.imagepicker.model.Folder;
 import com.esafirm.imagepicker.model.Image;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 class ImagePickerPresenter extends BasePresenter<ImagePickerView> {
@@ -44,12 +45,12 @@ class ImagePickerPresenter extends BasePresenter<ImagePickerView> {
         imageLoader.abortLoadImages();
     }
 
-    void loadImages(boolean isFolderMode) {
+    void loadImages(boolean isFolderMode, ArrayList<File> excludedImages) {
         if (!isViewAttached()) return;
 
         runOnUiIfAvailable(() -> getView().showLoading(true));
 
-        imageLoader.loadDeviceImages(isFolderMode, new ImageLoaderListener() {
+        imageLoader.loadDeviceImages(isFolderMode, excludedImages, new ImageLoaderListener() {
             @Override
             public void onImageLoaded(final List<Image> images, final List<Folder> folders) {
                 runOnUiIfAvailable(() -> {


### PR DESCRIPTION
Added option to exclude files from being display by providing either `File` or `Image` instances representing the path of the image. Closes #99.