### PR TITLE
Fixed the very long delay when initating the folder gallery picker

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImageFileLoader.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImageFileLoader.java
@@ -99,7 +99,7 @@ public class ImageFileLoader {
                     String bucket = cursor.getString(cursor.getColumnIndex(projection[3]));
 
                     File file = makeSafeFile(path);
-                    if (file != null && file.exists()) {
+                    if (file != null) {
                         if (exlucedImages != null && exlucedImages.contains(file))
                             continue;
 


### PR DESCRIPTION
As stated in the issue I opened before 2 weeks: https://github.com/esafirm/android-image-picker/issues/133 and by another user: https://github.com/esafirm/android-image-picker/issues/138
 The problem was relying in the check of `file.exists()` on each file. caused too much I/O blocking operations.
 The image picker now loads instantly instead of taking many seconds (11 seconds in my case). Depends on the amount of files in the user's gallery.
