### PR TITLE
Moves ImagePickerActivity's logic into a Fragment

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/ImagePickerAdapter.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/ImagePickerAdapter.java
@@ -1,8 +1,6 @@
 package com.esafirm.imagepicker.adapter;
 
 import android.content.Context;
-import androidx.core.content.ContextCompat;
-import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -20,10 +18,13 @@ import com.esafirm.imagepicker.model.Image;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
+
 public class ImagePickerAdapter extends BaseListAdapter<ImagePickerAdapter.ImageViewHolder> {
 
     private List<Image> images = new ArrayList<>();
-    private ArrayList<Image> selectedImages = new ArrayList<>();
+    private List<Image> selectedImages = new ArrayList<>();
 
     private OnImageClickListener itemClickListener;
     private OnImageSelectedListener imageSelectedListener;
@@ -149,7 +150,7 @@ public class ImagePickerAdapter extends BaseListAdapter<ImagePickerAdapter.Image
         return images.get(position);
     }
 
-    public ArrayList<Image> getSelectedImages() {
+    public List<Image> getSelectedImages() {
         return selectedImages;
     }
 

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/ImagePickerAdapter.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/ImagePickerAdapter.java
@@ -23,7 +23,7 @@ import java.util.List;
 public class ImagePickerAdapter extends BaseListAdapter<ImagePickerAdapter.ImageViewHolder> {
 
     private List<Image> images = new ArrayList<>();
-    private List<Image> selectedImages = new ArrayList<>();
+    private ArrayList<Image> selectedImages = new ArrayList<>();
 
     private OnImageClickListener itemClickListener;
     private OnImageSelectedListener imageSelectedListener;
@@ -149,7 +149,7 @@ public class ImagePickerAdapter extends BaseListAdapter<ImagePickerAdapter.Image
         return images.get(position);
     }
 
-    public List<Image> getSelectedImages() {
+    public ArrayList<Image> getSelectedImages() {
         return selectedImages;
     }
 

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePicker.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePicker.java
@@ -193,7 +193,7 @@ public abstract class ImagePicker {
         return this;
     }
 
-    protected ImagePickerConfig getConfig() {
+    public ImagePickerConfig getConfig() {
         LocaleManager.setLanguange(config.getLanguage());
         return config;
     }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.java
@@ -5,23 +5,9 @@ import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Parcelable;
-import android.provider.MediaStore;
-import android.provider.Settings;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.app.ActivityCompat;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.appcompat.widget.Toolbar;
-import androidx.fragment.app.FragmentTransaction;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.FrameLayout;
 
 import com.esafirm.imagepicker.R;
 import com.esafirm.imagepicker.features.cameraonly.CameraOnlyConfig;
@@ -34,12 +20,16 @@ import com.esafirm.imagepicker.model.Image;
 
 import java.util.List;
 
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.FragmentTransaction;
+
 public class ImagePickerActivity extends AppCompatActivity implements ImagePickerInteractionListener, ImagePickerView {
 
     private ActionBar actionBar;
     private ImagePickerFragment imagePickerFragment;
 
-    private CameraOnlyConfig cameraOnlyConfig;
     private ImagePickerConfig config;
 
     @Override
@@ -61,11 +51,18 @@ public class ImagePickerActivity extends AppCompatActivity implements ImagePicke
             return;
         }
         config = getIntent().getExtras().getParcelable(ImagePickerConfig.class.getSimpleName());
-        cameraOnlyConfig = getIntent().getExtras().getParcelable(CameraOnlyConfig.class.getSimpleName());
+        CameraOnlyConfig cameraOnlyConfig = getIntent().getExtras().getParcelable(CameraOnlyConfig.class.getSimpleName());
 
-        setTheme(config.getTheme());
-        setContentView(R.layout.ef_activity_image_picker);
-        setupView();
+        boolean isCameraOnly = cameraOnlyConfig != null;
+
+        // TODO extract camera only function so we don't have to rely to Fragment
+        if (!isCameraOnly) {
+            setTheme(config.getTheme());
+            setContentView(R.layout.ef_activity_image_picker);
+            setupView();
+        } else {
+            setContentView(createCameraLayout());
+        }
 
         if (savedInstanceState != null) {
             // The fragment has been restored.
@@ -76,6 +73,12 @@ public class ImagePickerActivity extends AppCompatActivity implements ImagePicke
             ft.replace(R.id.ef_imagepicker_fragment_placeholder, imagePickerFragment);
             ft.commit();
         }
+    }
+
+    private FrameLayout createCameraLayout() {
+        FrameLayout frameLayout = new FrameLayout(this);
+        frameLayout.setId(R.id.ef_imagepicker_fragment_placeholder);
+        return frameLayout;
     }
 
     /**

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.java
@@ -157,6 +157,7 @@ public class ImagePickerActivity extends AppCompatActivity implements ImagePicke
     @Override
     public void setTitle(String title) {
         actionBar.setTitle(title);
+        supportInvalidateOptionsMenu();
     }
 
     @Override

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 
 public class ImagePickerConfig extends BaseConfig implements Parcelable {
 
-    static final int NO_COLOR = -1;
+    public static final int NO_COLOR = -1;
 
     private ArrayList<Image> selectedImages;
     private ArrayList<File> excludedImages;

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.java
@@ -101,6 +101,13 @@ public class ImagePickerFragment extends Fragment implements ImagePickerView {
 
         setupComponents();
 
+        if (interactionListener == null) {
+            throw new RuntimeException("ImagePickerFragment needs an " +
+                    "ImagePickerInteractionListener. This will be set automatically if the " +
+                    "activity implements ImagePickerInteractionListener, and can be set manually " +
+                    "with fragment.setInteractionListener(listener).");
+        }
+
         if (savedInstanceState != null) {
             presenter.setCameraModule((DefaultCameraModule) savedInstanceState.getSerializable(STATE_KEY_CAMERA_MODULE));
         }
@@ -200,7 +207,6 @@ public class ImagePickerFragment extends Fragment implements ImagePickerView {
     }
 
     private void updateTitle() {
-        getActivity().invalidateOptionsMenu();
         interactionListener.setTitle(recyclerViewManager.getTitle());
     }
 
@@ -466,12 +472,12 @@ public class ImagePickerFragment extends Fragment implements ImagePickerView {
         super.onAttach(context);
         if (context instanceof ImagePickerInteractionListener) {
             interactionListener = (ImagePickerInteractionListener) context;
-        } else {
-            throw new RuntimeException(context.toString()
-                    + " must implement OnImagePickerInteractionListener");
         }
     }
 
+    public void setInteractionListener(ImagePickerInteractionListener listener) {
+        interactionListener = listener;
+    }
 
     /* --------------------------------------------------- */
     /* > View Methods */

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.java
@@ -13,12 +13,6 @@ import android.os.Handler;
 import android.os.Parcelable;
 import android.provider.MediaStore;
 import android.provider.Settings;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.app.ActivityCompat;
-import androidx.fragment.app.Fragment;
-import androidx.appcompat.view.ContextThemeWrapper;
-import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -41,6 +35,13 @@ import com.esafirm.imagepicker.view.SnackBarView;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.core.app.ActivityCompat;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.RecyclerView;
 
 import static android.app.Activity.RESULT_CANCELED;
 import static android.app.Activity.RESULT_OK;
@@ -187,7 +188,8 @@ public class ImagePickerFragment extends Fragment implements ImagePickerView {
         super.onSaveInstanceState(outState);
         outState.putSerializable(STATE_KEY_CAMERA_MODULE, presenter.getCameraModule());
         outState.putParcelable(STATE_KEY_RECYCLER, recyclerViewManager.getRecyclerState());
-        outState.putParcelableArrayList(STATE_KEY_SELECTED_IMAGES, recyclerViewManager.getSelectedImages());
+        outState.putParcelableArrayList(STATE_KEY_SELECTED_IMAGES, (ArrayList<? extends Parcelable>)
+                recyclerViewManager.getSelectedImages());
     }
 
     /**

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.java
@@ -1,0 +1,513 @@
+package com.esafirm.imagepicker.features;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.res.Configuration;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Parcelable;
+import android.provider.MediaStore;
+import android.provider.Settings;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.ActivityCompat;
+import androidx.fragment.app.Fragment;
+import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.recyclerview.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.esafirm.imagepicker.R;
+import com.esafirm.imagepicker.features.camera.CameraHelper;
+import com.esafirm.imagepicker.features.camera.DefaultCameraModule;
+import com.esafirm.imagepicker.features.cameraonly.CameraOnlyConfig;
+import com.esafirm.imagepicker.features.common.BaseConfig;
+import com.esafirm.imagepicker.features.recyclers.RecyclerViewManager;
+import com.esafirm.imagepicker.helper.ConfigUtils;
+import com.esafirm.imagepicker.helper.ImagePickerPreferences;
+import com.esafirm.imagepicker.helper.IpLogger;
+import com.esafirm.imagepicker.model.Folder;
+import com.esafirm.imagepicker.model.Image;
+import com.esafirm.imagepicker.view.SnackBarView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static android.app.Activity.RESULT_CANCELED;
+import static android.app.Activity.RESULT_OK;
+import static com.esafirm.imagepicker.helper.ImagePickerPreferences.PREF_WRITE_EXTERNAL_STORAGE_REQUESTED;
+
+public class ImagePickerFragment extends Fragment implements ImagePickerView {
+    private static final String STATE_KEY_CAMERA_MODULE = "Key.CameraModule";
+
+    private static final int RC_CAPTURE = 2000;
+
+    private static final int RC_PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 23;
+    private static final int RC_PERMISSION_REQUEST_CAMERA = 24;
+
+    private IpLogger logger = IpLogger.getInstance();
+
+    private RecyclerView recyclerView;
+    private SnackBarView snackBarView;
+    private ProgressBar progressBar;
+    private TextView emptyTextView;
+
+    private RecyclerViewManager recyclerViewManager;
+
+    private ImagePickerPresenter presenter;
+    private ImagePickerPreferences preferences;
+    private ImagePickerConfig config;
+    private CameraOnlyConfig cameraOnlyConfig;
+    private ImagePickerInteractionListener interactionListener;
+
+    private Handler handler;
+    private ContentObserver observer;
+
+    private boolean isCameraOnly;
+
+
+    public ImagePickerFragment() {
+        // Required empty public constructor.
+    }
+
+    public static ImagePickerFragment newInstance(ImagePickerConfig config, @Nullable CameraOnlyConfig cameraOnlyConfig) {
+        ImagePickerFragment fragment = new ImagePickerFragment();
+        Bundle args = new Bundle();
+        args.putParcelable(ImagePickerConfig.class.getSimpleName(), config);
+        if (cameraOnlyConfig != null) {
+            args.putParcelable(CameraOnlyConfig.class.getSimpleName(), cameraOnlyConfig);
+        }
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        config = getArguments().getParcelable(ImagePickerConfig.class.getSimpleName());
+        cameraOnlyConfig = getArguments().getParcelable(CameraOnlyConfig.class.getSimpleName());
+        isCameraOnly = cameraOnlyConfig != null;
+
+        setupComponents();
+
+        if (savedInstanceState != null) {
+            presenter.setCameraModule((DefaultCameraModule) savedInstanceState.getSerializable(STATE_KEY_CAMERA_MODULE));
+        }
+
+        if (isCameraOnly) {
+            if (savedInstanceState == null) {
+                captureImageWithPermission();
+            }
+        } else {
+            if (config != null) {
+                // clone the inflater using the ContextThemeWrapper
+                LayoutInflater localInflater = inflater.cloneInContext(new ContextThemeWrapper(getActivity(), config.getTheme()));
+
+                // inflate the layout using the cloned inflater, not default inflater
+                View result = localInflater.inflate(R.layout.ef_fragment_image_picker, container, false);
+                setupView(result);
+                setupRecyclerView(config);
+                return result;
+            }
+        }
+        return null;
+    }
+
+    private BaseConfig getBaseConfig() {
+        return isCameraOnly ? cameraOnlyConfig : config;
+    }
+
+    private void setupView(View rootView) {
+        progressBar = rootView.findViewById(R.id.progress_bar);
+        emptyTextView = rootView.findViewById(R.id.tv_empty_images);
+        recyclerView = rootView.findViewById(R.id.recyclerView);
+        snackBarView = rootView.findViewById(R.id.ef_snackbar);
+    }
+
+    private void setupRecyclerView(ImagePickerConfig config) {
+        recyclerViewManager = new RecyclerViewManager(
+                recyclerView,
+                config,
+                getResources().getConfiguration().orientation
+        );
+
+        recyclerViewManager.setupAdapters((isSelected) -> recyclerViewManager.selectImage(isSelected)
+                , bucket -> setImageAdapter(bucket.getImages()));
+
+        recyclerViewManager.setImageSelectedListener(selectedImage -> {
+            updateTitle();
+            interactionListener.selectionChanged(recyclerViewManager.getSelectedImages());
+            if (ConfigUtils.shouldReturn(config, false) && !selectedImage.isEmpty()) {
+                onDone();
+            }
+        });
+
+    }
+
+    private void setupComponents() {
+        preferences = new ImagePickerPreferences(getActivity());
+        presenter = new ImagePickerPresenter(new ImageFileLoader(getActivity()));
+        presenter.attachView(this);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (!isCameraOnly) {
+            getDataWithPermission();
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putSerializable(STATE_KEY_CAMERA_MODULE, presenter.getCameraModule());
+    }
+
+    /**
+     * Set image adapter
+     * 1. Set new data
+     * 2. Update item decoration
+     * 3. Update title
+     */
+    void setImageAdapter(List<Image> images) {
+        recyclerViewManager.setImageAdapter(images);
+        updateTitle();
+    }
+
+    void setFolderAdapter(List<Folder> folders) {
+        recyclerViewManager.setFolderAdapter(folders);
+        updateTitle();
+    }
+
+    private void updateTitle() {
+        getActivity().invalidateOptionsMenu();
+        interactionListener.setTitle(recyclerViewManager.getTitle());
+    }
+
+    /**
+     * On finish selected image
+     * Get all selected images then return image to caller activity
+     */
+    public void onDone() {
+        presenter.onDoneSelectImages(recyclerViewManager.getSelectedImages());
+    }
+
+    /**
+     * Config recyclerView when configuration changed
+     */
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        if (recyclerViewManager != null) {
+            // recyclerViewManager can be null here if we use cameraOnly mode
+            recyclerViewManager.changeOrientation(newConfig.orientation);
+        }
+    }
+
+    /**
+     * Check permission
+     */
+    private void getDataWithPermission() {
+        int rc = ActivityCompat.checkSelfPermission(getActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        if (rc == PackageManager.PERMISSION_GRANTED) {
+            getData();
+        } else {
+            requestWriteExternalPermission();
+        }
+    }
+
+    private void getData() {
+        presenter.abortLoad();
+        if (config != null) {
+            presenter.loadImages(config);
+        }
+    }
+
+    /**
+     * Request for permission
+     * If permission denied or app is first launched, request for permission
+     * If permission denied and user choose 'Never Ask Again', show snackbar with an action that navigate to app settings
+     */
+    private void requestWriteExternalPermission() {
+        logger.w("Write External permission is not granted. Requesting permission");
+
+        final String[] permissions = new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE};
+
+        if (ActivityCompat.shouldShowRequestPermissionRationale(getActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            requestPermissions(permissions, RC_PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE);
+        } else {
+            final String permission = PREF_WRITE_EXTERNAL_STORAGE_REQUESTED;
+            if (!preferences.isPermissionRequested(permission)) {
+                preferences.setPermissionRequested(permission);
+                requestPermissions(permissions, RC_PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE);
+            } else {
+                snackBarView.show(R.string.ef_msg_no_write_external_permission, v -> openAppSettings());
+            }
+        }
+    }
+
+    private void requestCameraPermissions() {
+        logger.w("Write External permission is not granted. Requesting permission");
+
+        ArrayList<String> permissions = new ArrayList<>(2);
+
+        if (ActivityCompat.checkSelfPermission(getActivity(), Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+            permissions.add(Manifest.permission.CAMERA);
+        }
+        if (ActivityCompat.checkSelfPermission(getActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            permissions.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        }
+
+        if (checkForRationale(permissions)) {
+            requestPermissions(permissions.toArray(new String[permissions.size()]), RC_PERMISSION_REQUEST_CAMERA);
+        } else {
+            final String permission = ImagePickerPreferences.PREF_CAMERA_REQUESTED;
+            if (!preferences.isPermissionRequested(permission)) {
+                preferences.setPermissionRequested(permission);
+                requestPermissions(permissions.toArray(new String[permissions.size()]), RC_PERMISSION_REQUEST_CAMERA);
+            } else {
+                if (isCameraOnly) {
+                    Toast.makeText(getActivity().getApplicationContext(),
+                            getString(R.string.ef_msg_no_camera_permission), Toast.LENGTH_SHORT).show();
+                    interactionListener.cancel();
+                } else {
+                    snackBarView.show(R.string.ef_msg_no_camera_permission, v -> openAppSettings());
+                }
+            }
+        }
+    }
+
+    private boolean checkForRationale(List<String> permissions) {
+        for (int i = 0, size = permissions.size(); i < size; i++) {
+            if (ActivityCompat.shouldShowRequestPermissionRationale(getActivity(), permissions.get(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Handle permission results
+     */
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        switch (requestCode) {
+            case RC_PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE: {
+                if (grantResults.length != 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    logger.d("Write External permission granted");
+                    getData();
+                    return;
+                }
+                logger.e("Permission not granted: results len = " + grantResults.length +
+                        " Result code = " + (grantResults.length > 0 ? grantResults[0] : "(empty)"));
+                interactionListener.cancel();
+            }
+            break;
+            case RC_PERMISSION_REQUEST_CAMERA: {
+                if (grantResults.length != 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    logger.d("Camera permission granted");
+                    captureImage();
+                    return;
+                }
+                logger.e("Permission not granted: results len = " + grantResults.length +
+                        " Result code = " + (grantResults.length > 0 ? grantResults[0] : "(empty)"));
+                interactionListener.cancel();
+                break;
+            }
+            default: {
+                logger.d("Got unexpected permission result: " + requestCode);
+                super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Open app settings screen
+     */
+    private void openAppSettings() {
+        Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.fromParts("package", getActivity().getPackageName(), null));
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(intent);
+    }
+
+    /**
+     * Check if the captured image is stored successfully
+     * Then reload data
+     */
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == RC_CAPTURE) {
+            if (resultCode == RESULT_OK) {
+                presenter.finishCaptureImage(getActivity(), data, getBaseConfig());
+            } else if (resultCode == RESULT_CANCELED && isCameraOnly) {
+                presenter.abortCaptureImage();
+                interactionListener.cancel();
+            }
+        }
+    }
+
+    /**
+     * Request for camera permission
+     */
+    public void captureImageWithPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            final boolean isCameraGranted = ActivityCompat
+                    .checkSelfPermission(getActivity(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED;
+            final boolean isWriteGranted = ActivityCompat
+                    .checkSelfPermission(getActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+            if (isCameraGranted && isWriteGranted) {
+                captureImage();
+            } else {
+                logger.w("Camera permission is not granted. Requesting permission");
+                requestCameraPermissions();
+            }
+        } else {
+            captureImage();
+        }
+    }
+
+    /**
+     * Start camera intent
+     * Create a temporary file and pass file Uri to camera intent
+     */
+    private void captureImage() {
+        if (!CameraHelper.checkCameraAvailability(getActivity())) {
+            return;
+        }
+        presenter.captureImage(this, getBaseConfig(), RC_CAPTURE);
+    }
+
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
+        if (isCameraOnly) {
+            return;
+        }
+
+        if (handler == null) {
+            handler = new Handler();
+        }
+        observer = new ContentObserver(handler) {
+            @Override
+            public void onChange(boolean selfChange) {
+                getData();
+            }
+        };
+        getActivity().getContentResolver().registerContentObserver(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, false, observer);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (presenter != null) {
+            presenter.abortLoad();
+            presenter.detachView();
+        }
+
+        if (observer != null) {
+            getActivity().getContentResolver().unregisterContentObserver(observer);
+            observer = null;
+        }
+
+        if (handler != null) {
+            handler.removeCallbacksAndMessages(null);
+            handler = null;
+        }
+    }
+
+    // Returns true if this Fragment can do anything with a "back" event, such as the containing
+    // Activity receiving onBackPressed(). Returns false if the containing Activity should handle
+    // it.
+    // This Fragment might handle a "back" event by, for example, going back to the list of folders.
+    // Or it might have no "back" to go, and return false.
+    public boolean handleBack() {
+        if (isCameraOnly) {
+            return false;
+        }
+        if (recyclerViewManager.handleBack()) {
+            // Handled.
+            updateTitle();
+            return true;
+        }
+        return false;
+    }
+
+    public boolean isShowDoneButton() {
+        return recyclerViewManager.isShowDoneButton();
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof ImagePickerInteractionListener) {
+            interactionListener = (ImagePickerInteractionListener) context;
+        } else {
+            throw new RuntimeException(context.toString()
+                    + " must implement OnImagePickerInteractionListener");
+        }
+    }
+
+
+    /* --------------------------------------------------- */
+    /* > View Methods */
+    /* --------------------------------------------------- */
+
+    @Override
+    public void finishPickImages(List<Image> images) {
+        Intent data = new Intent();
+        data.putParcelableArrayListExtra(IpCons.EXTRA_SELECTED_IMAGES, (ArrayList<? extends Parcelable>) images);
+        interactionListener.finishPickImages(data);
+    }
+
+    @Override
+    public void showCapturedImage() {
+        getDataWithPermission();
+    }
+
+    @Override
+    public void showFetchCompleted(List<Image> images, List<Folder> folders) {
+        if (config != null && config.isFolderMode()) {
+            setFolderAdapter(folders);
+        } else {
+            setImageAdapter(images);
+        }
+    }
+
+    @Override
+    public void showError(Throwable throwable) {
+        String message = "Unknown Error";
+        if (throwable != null && throwable instanceof NullPointerException) {
+            message = "Images do not exist";
+        }
+        Toast.makeText(getActivity(), message, Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void showLoading(boolean isLoading) {
+        progressBar.setVisibility(isLoading ? View.VISIBLE : View.GONE);
+        recyclerView.setVisibility(isLoading ? View.GONE : View.VISIBLE);
+        emptyTextView.setVisibility(View.GONE);
+    }
+
+    @Override
+    public void showEmpty() {
+        progressBar.setVisibility(View.GONE);
+        recyclerView.setVisibility(View.GONE);
+        emptyTextView.setVisibility(View.VISIBLE);
+    }
+}

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerInteractionListener.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerInteractionListener.java
@@ -1,0 +1,19 @@
+package com.esafirm.imagepicker.features;
+
+import android.content.Intent;
+
+import com.esafirm.imagepicker.model.Image;
+
+import java.util.List;
+
+public interface ImagePickerInteractionListener {
+    void setTitle(String title);
+    void cancel();
+    // Get this callback by calling an ImagePickerFragment's finishPickImages() method. It
+    // removes Images whose files no longer exist.
+    void finishPickImages(Intent result);
+    // May include Images whose files no longer exist. This is called every time the selection
+    // changes. Doing this is technically O(N^2), but since N is the number of times a user tapped
+    // individual photos, it isn't going to get too slow.
+    void selectionChanged(List<Image> imageList);
+}

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerInteractionListener.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerInteractionListener.java
@@ -12,8 +12,10 @@ public interface ImagePickerInteractionListener {
     // Get this callback by calling an ImagePickerFragment's finishPickImages() method. It
     // removes Images whose files no longer exist.
     void finishPickImages(Intent result);
-    // May include Images whose files no longer exist. This is called every time the selection
-    // changes. Doing this is technically O(N^2), but since N is the number of times a user tapped
-    // individual photos, it isn't going to get too slow.
+
+    /**
+     * Called when the user selects or deselects sn image. Also called in onCreateView.
+     * May include Images whose files no longer exist.
+     */
     void selectionChanged(List<Image> imageList);
 }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.java
@@ -1,10 +1,10 @@
 package com.esafirm.imagepicker.features;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Handler;
 import android.os.Looper;
+import androidx.fragment.app.Fragment;
 import android.widget.Toast;
 
 import com.esafirm.imagepicker.R;
@@ -96,14 +96,14 @@ class ImagePickerPresenter extends BasePresenter<ImagePickerView> {
         }
     }
 
-    void captureImage(Activity activity, BaseConfig config, int requestCode) {
-        Context context = activity.getApplicationContext();
-        Intent intent = getCameraModule().getCameraIntent(activity, config);
+    void captureImage(Fragment fragment, BaseConfig config, int requestCode) {
+        Context context = fragment.getActivity().getApplicationContext();
+        Intent intent = getCameraModule().getCameraIntent(fragment.getActivity(), config);
         if (intent == null) {
             Toast.makeText(context, context.getString(R.string.ef_error_create_image_file), Toast.LENGTH_LONG).show();
             return;
         }
-        activity.startActivityForResult(intent, requestCode);
+        fragment.startActivityForResult(intent, requestCode);
     }
 
     void finishCaptureImage(Context context, Intent data, final BaseConfig config) {

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/recyclers/OnBackAction.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/recyclers/OnBackAction.java
@@ -1,6 +1,0 @@
-package com.esafirm.imagepicker.features.recyclers;
-
-public interface OnBackAction {
-    void onBackToFolder();
-    void onFinishImagePicker();
-}

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/recyclers/RecyclerViewManager.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/recyclers/RecyclerViewManager.java
@@ -3,9 +3,6 @@ package com.esafirm.imagepicker.features.recyclers;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Parcelable;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.GridLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import android.widget.Toast;
 
 import com.esafirm.imagepicker.R;
@@ -25,6 +22,9 @@ import com.esafirm.imagepicker.view.GridSpacingItemDecoration;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import static com.esafirm.imagepicker.features.IpCons.MAX_LIMIT;
 import static com.esafirm.imagepicker.features.IpCons.MODE_MULTIPLE;
@@ -164,7 +164,7 @@ public class RecyclerViewManager {
         }
     }
 
-    public ArrayList<Image> getSelectedImages() {
+    public List<Image> getSelectedImages() {
         checkAdapterIsInitialized();
         return imageAdapter.getSelectedImages();
     }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/recyclers/RecyclerViewManager.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/recyclers/RecyclerViewManager.java
@@ -3,6 +3,7 @@ package com.esafirm.imagepicker.features.recyclers;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Parcelable;
+import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import android.widget.Toast;
@@ -53,6 +54,14 @@ public class RecyclerViewManager {
         changeOrientation(orientation);
     }
 
+    public void onRestoreState(Parcelable recyclerState) {
+        layoutManager.onRestoreInstanceState(recyclerState);
+    }
+
+    public Parcelable getRecyclerState() {
+        return layoutManager.onSaveInstanceState();
+    }
+
     /**
      * Set item size, column size base on the screen orientation
      */
@@ -68,12 +77,10 @@ public class RecyclerViewManager {
         setItemDecoration(columns);
     }
 
-    public void setupAdapters(OnImageClickListener onImageClickListener, OnFolderClickListener onFolderClickListener) {
-        ArrayList<Image> selectedImages = null;
-        if (config.getMode() == MODE_MULTIPLE && !config.getSelectedImages().isEmpty()) {
-            selectedImages = config.getSelectedImages();
+    public void setupAdapters(ArrayList<Image> selectedImages, OnImageClickListener onImageClickListener, OnFolderClickListener onFolderClickListener) {
+        if (config.getMode() == MODE_SINGLE && selectedImages != null && selectedImages.size() > 1) {
+            selectedImages = null;
         }
-
         /* Init folder and image adapter */
         final ImageLoader imageLoader = config.getImageLoader();
         imageAdapter = new ImagePickerAdapter(context, imageLoader, selectedImages, onImageClickListener);
@@ -157,7 +164,7 @@ public class RecyclerViewManager {
         }
     }
 
-    public List<Image> getSelectedImages() {
+    public ArrayList<Image> getSelectedImages() {
         checkAdapterIsInitialized();
         return imageAdapter.getSelectedImages();
     }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/recyclers/RecyclerViewManager.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/recyclers/RecyclerViewManager.java
@@ -97,13 +97,13 @@ public class RecyclerViewManager {
         layoutManager.setSpanCount(columns);
     }
 
-    public void handleBack(OnBackAction action) {
+    // Returns true if a back action was handled by going back a folder; false otherwise.
+    public boolean handleBack() {
         if (config.isFolderMode() && !isDisplayingFolderView()) {
             setFolderAdapter(null);
-            action.onBackToFolder();
-            return;
+            return true;
         }
-        action.onFinishImagePicker();
+        return false;
     }
 
     private boolean isDisplayingFolderView() {

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/helper/IpCrasher.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/helper/IpCrasher.java
@@ -1,0 +1,7 @@
+package com.esafirm.imagepicker.helper;
+
+public class IpCrasher {
+    public static void openIssue() {
+        throw new IllegalStateException("This should not happen. Please open an issue!");
+    }
+}

--- a/imagepicker/src/main/res/layout/ef_activity_image_picker.xml
+++ b/imagepicker/src/main/res/layout/ef_activity_image_picker.xml
@@ -11,35 +11,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
-    <TextView
-        android:id="@+id/tv_empty_images"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:padding="@dimen/ef_spacing_double"
-        android:text="@string/ef_msg_empty_images"
-        android:textSize="@dimen/ef_font_medium"
-        android:visibility="gone"/>
 
-    <ProgressBar
-        android:id="@+id/progress_bar"
-        android:layout_width="100dp"
-        android:layout_height="100dp"
-        android:layout_centerInParent="true"
-        android:visibility="gone"/>
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerView"
+    <FrameLayout
+        android:id="@+id/ef_imagepicker_fragment_placeholder"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@+id/toolbar"/>
-
-    <com.esafirm.imagepicker.view.SnackBarView
-        android:id="@+id/ef_snackbar"
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:layout_alignBottom="@+id/recyclerView"
-        android:layout_alignParentBottom="true"
-        android:background="@color/ef_black_alpha_aa"/>
+        android:layout_below="@id/toolbar" />
 
 </RelativeLayout>

--- a/imagepicker/src/main/res/layout/ef_fragment_image_picker.xml
+++ b/imagepicker/src/main/res/layout/ef_fragment_image_picker.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/tv_empty_images"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:padding="@dimen/ef_spacing_double"
+        android:text="@string/ef_msg_empty_images"
+        android:textSize="@dimen/ef_font_medium"
+        android:visibility="gone"/>
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:layout_centerInParent="true"
+        android:visibility="gone"/>
+
+    <com.esafirm.imagepicker.view.SnackBarView
+        android:id="@+id/ef_snackbar"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:layout_alignBottom="@+id/recyclerView"
+        android:layout_alignParentBottom="true"
+        android:background="@color/ef_black_alpha_aa"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+</RelativeLayout>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.esafirm.sample">
+    package="com.esafirm.sample">
 
     <application
         android:allowBackup="true"
@@ -10,10 +10,13 @@
         android:theme="@style/AppTheme">
         <activity android:name="com.esafirm.sample.MainActivity">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".CustomUIActivity"
+            android:configChanges="orientation|screenSize"
+            android:theme="@style/ef_AppTheme" />
     </application>
 
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -14,8 +14,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".CustomUIActivity"
-            android:configChanges="orientation|screenSize"
+        <activity
+            android:name=".CustomUIActivity"
             android:theme="@style/ef_AppTheme" />
     </application>
 

--- a/sample/src/main/java/com/esafirm/sample/CustomUIActivity.java
+++ b/sample/src/main/java/com/esafirm/sample/CustomUIActivity.java
@@ -30,7 +30,7 @@ import java.util.List;
  * This custom UI for ImagePicker puts the picker in the bottom half of the screen, and a preview of
  * the last selected image in the top half.
  */
-public class CustomUIActivity extends AppCompatActivity implements ImagePickerInteractionListener {
+public class CustomUIActivity extends AppCompatActivity {
 
     private ActionBar actionBar;
     private ImageView photoPreview;
@@ -66,6 +66,10 @@ public class CustomUIActivity extends AppCompatActivity implements ImagePickerIn
             ft.replace(R.id.ef_imagepicker_fragment_placeholder, imagePickerFragment);
             ft.commit();
         }
+        // For demonstration purposes, we're using a custom ImagePickerInteractionListener. Instead
+        // of calling setInteractionListener, though, we could simply implement
+        // ImagePickerInteractionListener in this class.
+        imagePickerFragment.setInteractionListener(new CustomInteractionListener());
     }
 
     /**
@@ -148,33 +152,32 @@ public class CustomUIActivity extends AppCompatActivity implements ImagePickerIn
         photoPreview = findViewById(R.id.photo_preview);
     }
 
-    /* --------------------------------------------------- */
-    /* > ImagePickerInteractionListener Methods */
-    /* --------------------------------------------------- */
-
-    @Override
-    public void setTitle(String title) {
-        actionBar.setTitle(title);
-    }
-
-    @Override
-    public void cancel() {
-        finish();
-    }
-
-    @Override
-    public void selectionChanged(List<Image> imageList) {
-        if (imageList.isEmpty()) {
-            photoPreview.setImageDrawable(null);
-        } else {
-            photoPreview.setImageBitmap(BitmapFactory.decodeFile(imageList.get(imageList.size() - 1).getPath()));
-
+    class CustomInteractionListener implements ImagePickerInteractionListener {
+        @Override
+        public void setTitle(String title) {
+            actionBar.setTitle(title);
+            supportInvalidateOptionsMenu();
         }
-    }
 
-    @Override
-    public void finishPickImages(Intent result) {
-        setResult(RESULT_OK, result);
-        finish();
+        @Override
+        public void cancel() {
+            finish();
+        }
+
+        @Override
+        public void selectionChanged(List<Image> imageList) {
+            if (imageList.isEmpty()) {
+                photoPreview.setImageDrawable(null);
+            } else {
+                photoPreview.setImageBitmap(BitmapFactory.decodeFile(imageList.get(imageList.size() - 1).getPath()));
+
+            }
+        }
+
+        @Override
+        public void finishPickImages(Intent result) {
+            setResult(RESULT_OK, result);
+            finish();
+        }
     }
 }

--- a/sample/src/main/java/com/esafirm/sample/CustomUIActivity.java
+++ b/sample/src/main/java/com/esafirm/sample/CustomUIActivity.java
@@ -1,42 +1,39 @@
-package com.esafirm.imagepicker.features;
+package com.esafirm.sample;
 
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.BitmapFactory;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
-import android.os.Bundle;
-import android.os.Handler;
-import android.os.Parcelable;
-import android.provider.MediaStore;
-import android.provider.Settings;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.app.ActivityCompat;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
 import androidx.appcompat.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.ImageView;
 
-import com.esafirm.imagepicker.R;
+import com.esafirm.imagepicker.features.ImagePickerConfig;
+import com.esafirm.imagepicker.features.ImagePickerFragment;
+import com.esafirm.imagepicker.features.ImagePickerInteractionListener;
 import com.esafirm.imagepicker.features.cameraonly.CameraOnlyConfig;
 import com.esafirm.imagepicker.helper.ConfigUtils;
 import com.esafirm.imagepicker.helper.IpLogger;
 import com.esafirm.imagepicker.helper.LocaleManager;
 import com.esafirm.imagepicker.helper.ViewUtils;
-import com.esafirm.imagepicker.model.Folder;
 import com.esafirm.imagepicker.model.Image;
 
 import java.util.List;
 
-public class ImagePickerActivity extends AppCompatActivity implements ImagePickerInteractionListener, ImagePickerView {
+/**
+ * This custom UI for ImagePicker puts the picker in the bottom half of the screen, and a preview of
+ * the last selected image in the top half.
+ */
+public class CustomUIActivity extends AppCompatActivity implements ImagePickerInteractionListener {
 
     private ActionBar actionBar;
+    private ImageView photoPreview;
     private ImagePickerFragment imagePickerFragment;
 
     private CameraOnlyConfig cameraOnlyConfig;
@@ -50,27 +47,20 @@ public class ImagePickerActivity extends AppCompatActivity implements ImagePicke
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
         setResult(RESULT_CANCELED);
 
-        /* This should not happen */
-        Intent intent = getIntent();
-        if (intent == null || intent.getExtras() == null) {
-            IpLogger.getInstance().e("This should not happen. Please open an issue!");
-            finish();
-            return;
-        }
         config = getIntent().getExtras().getParcelable(ImagePickerConfig.class.getSimpleName());
         cameraOnlyConfig = getIntent().getExtras().getParcelable(CameraOnlyConfig.class.getSimpleName());
-
         setTheme(config.getTheme());
-        setContentView(R.layout.ef_activity_image_picker);
+        setContentView(R.layout.activity_custom_ui);
         setupView();
 
         if (savedInstanceState != null) {
             // The fragment has been restored.
+            IpLogger.getInstance().e("Fragment has been restored");
             imagePickerFragment = (ImagePickerFragment) getSupportFragmentManager().findFragmentById(R.id.ef_imagepicker_fragment_placeholder);
         } else {
+            IpLogger.getInstance().e("Making fragment");
             imagePickerFragment = ImagePickerFragment.newInstance(config, cameraOnlyConfig);
             FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
             ft.replace(R.id.ef_imagepicker_fragment_placeholder, imagePickerFragment);
@@ -79,24 +69,24 @@ public class ImagePickerActivity extends AppCompatActivity implements ImagePicke
     }
 
     /**
-     * Create option menus.
+     * Create options menu.
      */
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.ef_image_picker_menu_main, menu);
+        getMenuInflater().inflate(com.esafirm.imagepicker.R.menu.ef_image_picker_menu_main, menu);
         return true;
     }
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
-        MenuItem menuCamera = menu.findItem(R.id.menu_camera);
+        MenuItem menuCamera = menu.findItem(com.esafirm.imagepicker.R.id.menu_camera);
         if (menuCamera != null) {
             if (config != null) {
                 menuCamera.setVisible(config.isShowCamera());
             }
         }
 
-        MenuItem menuDone = menu.findItem(R.id.menu_done);
+        MenuItem menuDone = menu.findItem(com.esafirm.imagepicker.R.id.menu_done);
         if (menuDone != null) {
             menuDone.setTitle(ConfigUtils.getDoneButtonText(this, config));
             menuDone.setVisible(imagePickerFragment.isShowDoneButton());
@@ -105,7 +95,7 @@ public class ImagePickerActivity extends AppCompatActivity implements ImagePicke
     }
 
     /**
-     * Handle option menu's click event
+     * Handle options menu's click event.
      */
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
@@ -115,17 +105,23 @@ public class ImagePickerActivity extends AppCompatActivity implements ImagePicke
             onBackPressed();
             return true;
         }
-        if (id == R.id.menu_done) {
+        if (id == com.esafirm.imagepicker.R.id.menu_done) {
             imagePickerFragment.onDone();
             return true;
         }
-        if (id == R.id.menu_camera) {
+        if (id == com.esafirm.imagepicker.R.id.menu_camera) {
             imagePickerFragment.captureImageWithPermission();
             return true;
         }
         return super.onOptionsItemSelected(item);
     }
 
+    /**
+     * If you're content for the back button to take you back, without consulting the state of the
+     * fragment, you don't need to override this. On the other hand, the ImagePickerFragment might
+     * want to handle the back button. For example, if it's in folder mode and a folder has been
+     * selected, the fragment will go back to the folder list if you call its handleBack().
+     */
     @Override
     public void onBackPressed() {
         if (!imagePickerFragment.handleBack()) {
@@ -148,6 +144,8 @@ public class ImagePickerActivity extends AppCompatActivity implements ImagePicke
             actionBar.setHomeAsUpIndicator(arrowDrawable);
             actionBar.setDisplayShowTitleEnabled(true);
         }
+
+        photoPreview = findViewById(R.id.photo_preview);
     }
 
     /* --------------------------------------------------- */
@@ -166,46 +164,17 @@ public class ImagePickerActivity extends AppCompatActivity implements ImagePicke
 
     @Override
     public void selectionChanged(List<Image> imageList) {
-        // Do nothing when the selection changes.
+        if (imageList.isEmpty()) {
+            photoPreview.setImageDrawable(null);
+        } else {
+            photoPreview.setImageBitmap(BitmapFactory.decodeFile(imageList.get(imageList.size() - 1).getPath()));
+
+        }
     }
 
     @Override
     public void finishPickImages(Intent result) {
         setResult(RESULT_OK, result);
         finish();
-    }
-
-    /* --------------------------------------------------- */
-    /* > View Methods  */
-    /* --------------------------------------------------- */
-
-    @Override
-    public void showLoading(boolean isLoading) {
-        imagePickerFragment.showLoading(isLoading);
-    }
-
-    @Override
-    public void showFetchCompleted(List<Image> images, List<Folder> folders) {
-        imagePickerFragment.showFetchCompleted(images, folders);
-    }
-
-    @Override
-    public void showError(Throwable throwable) {
-        imagePickerFragment.showError(throwable);
-    }
-
-    @Override
-    public void showEmpty() {
-        imagePickerFragment.showEmpty();
-    }
-
-    @Override
-    public void showCapturedImage() {
-        imagePickerFragment.showCapturedImage();
-    }
-
-    @Override
-    public void finishPickImages(List<Image> images) {
-        imagePickerFragment.finishPickImages(images);
     }
 }

--- a/sample/src/main/java/com/esafirm/sample/MainActivity.java
+++ b/sample/src/main/java/com/esafirm/sample/MainActivity.java
@@ -10,8 +10,11 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.widget.Switch;
 import android.widget.TextView;
 import com.esafirm.imagepicker.features.ImagePicker;
+import com.esafirm.imagepicker.features.ImagePickerActivity;
+import com.esafirm.imagepicker.features.ImagePickerConfig;
 import com.esafirm.imagepicker.features.IpCons;
 import com.esafirm.imagepicker.features.ReturnMode;
+import com.esafirm.imagepicker.helper.ConfigUtils;
 import com.esafirm.imagepicker.model.Image;
 import com.esafirm.rximagepicker.RxImagePicker;
 import rx.Observable;
@@ -37,9 +40,8 @@ public class MainActivity extends AppCompatActivity {
         findViewById(R.id.button_pick_image).setOnClickListener(view -> start());
         findViewById(R.id.button_pick_image_rx).setOnClickListener(view -> getImagePickerObservable().forEach(action));
         findViewById(R.id.button_intent).setOnClickListener(v -> startWithIntent());
-        findViewById(R.id.button_camera).setOnClickListener(v -> {
-            captureImage();
-        });
+        findViewById(R.id.button_camera).setOnClickListener(v -> captureImage());
+        findViewById(R.id.button_custom_ui).setOnClickListener(v -> startCustomUI());
 
         findViewById(R.id.button_launch_fragment)
                 .setOnClickListener(view -> getSupportFragmentManager().beginTransaction()
@@ -68,14 +70,7 @@ public class MainActivity extends AppCompatActivity {
                 .start(this, ImagePicker.create(this));
     }
 
-    private void startWithIntent() {
-        startActivityForResult(ImagePicker.create(this)
-                .single()
-                .returnMode(ReturnMode.ALL)
-                .getIntent(this), IpCons.RC_IMAGE_PICKER);
-    }
-
-    public void start() {
+    private ImagePicker getImagePicker() {
         final boolean returnAfterCapture = ((Switch) findViewById(R.id.ef_switch_return_after_capture)).isChecked();
         final boolean isSingleMode = ((Switch) findViewById(R.id.ef_switch_single)).isChecked();
         final boolean useCustomImageLoader = ((Switch) findViewById(R.id.ef_switch_imageloader)).isChecked();
@@ -112,11 +107,25 @@ public class MainActivity extends AppCompatActivity {
             imagePicker.origin(images); // original selected images, used in multi mode
         }
 
-        imagePicker.limit(10) // max images can be selected (99 by default)
+        return imagePicker.limit(10) // max images can be selected (99 by default)
                 .showCamera(true) // show camera or not (true by default)
                 .imageDirectory("Camera")   // captured image directory name ("Camera" folder by default)
-                .imageFullDirectory(Environment.getExternalStorageDirectory().getPath()) // can be full path
-                .start(); // start image picker activity with request code
+                .imageFullDirectory(Environment.getExternalStorageDirectory().getPath()); // can be full path
+    }
+
+    private void startWithIntent() {
+        startActivityForResult(getImagePicker().getIntent(this), IpCons.RC_IMAGE_PICKER);
+    }
+
+    private void start() {
+        getImagePicker().start(); // start image picker activity with request code
+    }
+
+    private void startCustomUI() {
+        ImagePickerConfig config = ConfigUtils.checkConfig(getImagePicker().getConfig());
+        Intent intent = new Intent(this, CustomUIActivity.class);
+        intent.putExtra(ImagePickerConfig.class.getSimpleName(), config);
+        startActivityForResult(intent, IpCons.RC_IMAGE_PICKER);
     }
 
     @Override

--- a/sample/src/main/res/layout/activity_custom_ui.xml
+++ b/sample/src/main/res/layout/activity_custom_ui.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/ef_imagepicker_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/toolbar"
+        android:orientation="vertical"
+        android:weightSum="100">
+        <ImageView
+            android:id="@+id/photo_preview"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="50"
+            android:contentDescription="Preview of selected photo"
+            android:scaleType="fitCenter" />
+        <FrameLayout
+            android:id="@+id/ef_imagepicker_fragment_placeholder"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="50"/>
+
+    </LinearLayout>
+
+
+</RelativeLayout>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -122,13 +122,19 @@
                 android:id="@+id/button_camera"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="CAMERA ONLY"/>
+                android:text="Camera"/>
 
             <Button
                 android:id="@+id/button_intent"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Get Intent"/>
+                android:text="Intent"/>
+
+            <Button
+                android:id="@+id/button_custom_ui"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Custom UI"/>
 
         </LinearLayout>
 


### PR DESCRIPTION
…called ImagePickerFragment. Keeps the toolbar and menus in the Activity.

This also adds a custom Activity to the sample app that is very similar to ImagePickerActivity, but includes a larger-sized preview.

Replaces #164, which I sort-of-accidentally squished due to some Git challenges. 