### PR TITLE
Fix - Memory leak ContentResolver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
-        classpath 'me.tatarka:gradle-retrolambda:3.7.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }

--- a/imagepicker/build.gradle
+++ b/imagepicker/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePicker.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePicker.java
@@ -195,11 +195,11 @@ public abstract class ImagePicker {
 
     public ImagePickerConfig getConfig() {
         LocaleManager.setLanguange(config.getLanguage());
-        return config;
+        return ConfigUtils.checkConfig(config);
     }
 
     public Intent getIntent(Context context) {
-        ImagePickerConfig config = ConfigUtils.checkConfig(getConfig());
+        ImagePickerConfig config = getConfig();
         Intent intent = new Intent(context, ImagePickerActivity.class);
         intent.putExtra(ImagePickerConfig.class.getSimpleName(), config);
         return intent;

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.java
@@ -99,8 +99,6 @@ public class ImagePickerFragment extends Fragment implements ImagePickerView {
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        isCameraOnly = getArguments().containsKey(CameraOnlyConfig.class.getSimpleName());
-
         setupComponents();
 
         if (interactionListener == null) {
@@ -139,6 +137,13 @@ public class ImagePickerFragment extends Fragment implements ImagePickerView {
             return result;
         }
         return null;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        isCameraOnly = getArguments().containsKey(CameraOnlyConfig.class.getSimpleName());
+        startContentObserver();
     }
 
     private BaseConfig getBaseConfig() {
@@ -439,15 +444,10 @@ public class ImagePickerFragment extends Fragment implements ImagePickerView {
         presenter.captureImage(this, getBaseConfig(), RC_CAPTURE);
     }
 
-
-    @Override
-    public void onStart() {
-        super.onStart();
-
+    private void startContentObserver() {
         if (isCameraOnly) {
             return;
         }
-
         if (handler == null) {
             handler = new Handler();
         }
@@ -457,8 +457,11 @@ public class ImagePickerFragment extends Fragment implements ImagePickerView {
                 getData();
             }
         };
-        getActivity().getContentResolver().registerContentObserver(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, false, observer);
+
+        getActivity().getContentResolver()
+                .registerContentObserver(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, false, observer);
     }
+
 
     @Override
     public void onDestroy() {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     implementation project(':rximagepicker')
     implementation project(':imagepicker')
 
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.6.2'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-support-fragment:1.6.2'
+
     /* Release Check */
 //    final imagePickerVersion = '1.13.1'
 //    compile "com.github.esafirm.android-image-picker:imagepicker:${imagePickerVersion}"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.esafirm.sample">
 
     <application
+        android:name=".SampleApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/sample/src/main/java/com/esafirm/sample/MainActivity.java
+++ b/sample/src/main/java/com/esafirm/sample/MainActivity.java
@@ -5,23 +5,23 @@ import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Environment;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import android.widget.Switch;
 import android.widget.TextView;
+
 import com.esafirm.imagepicker.features.ImagePicker;
-import com.esafirm.imagepicker.features.ImagePickerActivity;
 import com.esafirm.imagepicker.features.ImagePickerConfig;
 import com.esafirm.imagepicker.features.IpCons;
 import com.esafirm.imagepicker.features.ReturnMode;
-import com.esafirm.imagepicker.helper.ConfigUtils;
 import com.esafirm.imagepicker.model.Image;
 import com.esafirm.rximagepicker.RxImagePicker;
-import rx.Observable;
-import rx.functions.Action1;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import rx.Observable;
+import rx.functions.Action1;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -122,7 +122,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void startCustomUI() {
-        ImagePickerConfig config = ConfigUtils.checkConfig(getImagePicker().getConfig());
+        ImagePickerConfig config = getImagePicker().getConfig();
         Intent intent = new Intent(this, CustomUIActivity.class);
         intent.putExtra(ImagePickerConfig.class.getSimpleName(), config);
         startActivityForResult(intent, IpCons.RC_IMAGE_PICKER);

--- a/sample/src/main/java/com/esafirm/sample/SampleApplication.java
+++ b/sample/src/main/java/com/esafirm/sample/SampleApplication.java
@@ -1,0 +1,17 @@
+package com.esafirm.sample;
+
+import android.app.Application;
+
+import com.squareup.leakcanary.LeakCanary;
+
+public class SampleApplication extends Application {
+  @Override public void onCreate() {
+    super.onCreate();
+    if (LeakCanary.isInAnalyzerProcess(this)) {
+      // This process is dedicated to LeakCanary for heap analysis.
+      // You should not init your app in this process.
+      return;
+    }
+    LeakCanary.install(this);
+  }
+}


### PR DESCRIPTION
I am using android-image-picker inside an app were we are using [leakcanary](https://github.com/square/leakcanary) in debug builds. I received a memory leak warning about the ContentResolver.

The reason is, that the `ContentObserver` is registered in `onStart`, but unregistered in `onDestroy`.

How to reproduce: 
1. Use leakcanary (first commit) and start sample app
2. Start the image picker
3. Press back
4. Start image picker again
5. You'll see leakcanary dumping the heap

I tested a bit with the sample and it doesn't seem to introduce new bugs.