### PR TITLE
Update glide 4.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/android:api-27-alpha
+      - image: circleci/android:api-28-alpha
 
     environment:
       # Customize the JVM maximum heap limit

--- a/imagepicker/build.gradle
+++ b/imagepicker/build.gradle
@@ -44,10 +44,10 @@ artifacts {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    implementation "com.github.bumptech.glide:glide:4.5.0"
+    implementation "com.github.bumptech.glide:glide:4.9.0"
 
     implementation "androidx.recyclerview:recyclerview:1.0.0"
-    implementation "androidx.appcompat:appcompat:1.0.0"
+    implementation "androidx.appcompat:appcompat:1.0.2"
 
     testImplementation 'junit:junit:4.12'
 }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/imageloader/DefaultImageLoader.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/imageloader/DefaultImageLoader.java
@@ -13,8 +13,8 @@ public class DefaultImageLoader implements ImageLoader {
     public void loadImage(String path, ImageView imageView, ImageType imageType) {
         Glide.with(imageView.getContext())
                 .load(path)
-                .apply(new RequestOptions()
-                        .placeholder(imageType == ImageType.FOLDER
+                .apply(RequestOptions
+                        .placeholderOf(imageType == ImageType.FOLDER
                                 ? R.drawable.ef_folder_placeholder
                                 : R.drawable.ef_image_placeholder)
                         .error(imageType == ImageType.FOLDER

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -34,8 +34,8 @@ repositories {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    implementation "com.github.bumptech.glide:glide:4.5.0"
-    implementation "androidx.appcompat:appcompat:1.0.0"
+    implementation "com.github.bumptech.glide:glide:4.9.0"
+    implementation "androidx.appcompat:appcompat:1.0.2"
 
     /* Development */
     implementation project(':rximagepicker')

--- a/setup.sh
+++ b/setup.sh
@@ -4,3 +4,12 @@ echo "include ':imagepicker'" > settings.gradle
 echo "include ':rximagepicker'" >> settings.gradle
 
 cat settings.gradle
+
+cd $ANDROID_HOME
+mkdir -p licenses
+
+cat << EOF >> licenses/android-sdk-license
+8933bad161af4178b1185d1a37fbf41ea5269c55
+d56f5187479451eabf01fb78af6dfcb131a6481e
+24333f8a63b6825ea9c5514f83c2829b004d1fee
+EOF


### PR DESCRIPTION
Updated glide 4.9.0, and fixed [issue 196](https://github.com/esafirm/android-image-picker/issues/196)