### PR TITLE
Duplicated images when taking photo

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerSavePath.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerSavePath.java
@@ -5,7 +5,7 @@ import android.os.Parcelable;
 
 public class ImagePickerSavePath implements Parcelable {
 
-    public static final ImagePickerSavePath DEFAULT = new ImagePickerSavePath("Camera", false);
+    public static final ImagePickerSavePath DEFAULT = new ImagePickerSavePath(null, false);
 
     private final String path;
     private final boolean isFullPath;

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/DefaultCameraModule.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/DefaultCameraModule.java
@@ -28,6 +28,10 @@ public class DefaultCameraModule implements CameraModule, Serializable {
     @Override
     public Intent getCameraIntent(Context context, BaseConfig config) {
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        if (config.getImageDirectory().getPath() == null) {
+            return intent;
+        }
+
         File imageFile = ImagePickerUtils.createImageFile(config.getImageDirectory());
         if (imageFile != null) {
             Context appContext = context.getApplicationContext();


### PR DESCRIPTION
Setting null as default for Camera image directory. This allows the option to set a directory and avoids duplicated files when taking a photo from the image picker.