### PR TITLE
Fix Locale code for language function

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePicker.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePicker.java
@@ -199,7 +199,7 @@ public abstract class ImagePicker {
     }
 
     public ImagePickerConfig getConfig() {
-        LocaleManager.setLanguange(config.getLanguage());
+        LocaleManager.setLanguage(config.getLanguage());
         return ConfigUtils.checkConfig(config);
     }
 

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/helper/LocaleManager.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/helper/LocaleManager.java
@@ -23,7 +23,7 @@ public class LocaleManager {
     public static Context updateResources(Context context) {
 
         Locale locale = new Locale(getLanguage());
-        locale = zhCheck(locale);
+        locale = normalizeLocale(locale);
         Locale.setDefault(locale);
 
         Resources res = context.getResources();
@@ -38,29 +38,29 @@ public class LocaleManager {
         return context;
     }
 
-    private static Locale zhCheck(Locale newLocaleLanguage) {
+    private static Locale normalizeLocale(Locale localeLanguage) {
         final String ZH = "zh";
         final String TW = "TW";
         final String CN = "CN";
 
-        Locale mLocale;
-        String mNewLocaleLanguage = String.valueOf(newLocaleLanguage);
+        Locale locale;
+        String newLocaleLanguage = String.valueOf(localeLanguage);
 
-        if (mNewLocaleLanguage.length() == 5) {
-            mLocale = new Locale(
-                    mNewLocaleLanguage.substring(0, 2),
-                    mNewLocaleLanguage.substring(3, 5).toUpperCase()
+        if (newLocaleLanguage.length() == 5) {
+            locale = new Locale(
+                    newLocaleLanguage.substring(0, 2),
+                    newLocaleLanguage.substring(3, 5).toUpperCase()
             );
-            return mLocale;
-        } else if (mNewLocaleLanguage.equals(ZH)) {
+            return locale;
+        } else if (newLocaleLanguage.equals(ZH)) {
             if (Locale.getDefault().getCountry().equals(TW)) {
-                mLocale = new Locale(ZH, TW);
+                locale = new Locale(ZH, TW);
             } else {
-                mLocale = new Locale(ZH, CN);
+                locale = new Locale(ZH, CN);
             }
-            return mLocale;
+            return locale;
         } else {
-            return newLocaleLanguage;
+            return localeLanguage;
         }
     }
 }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/helper/LocaleManager.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/helper/LocaleManager.java
@@ -4,14 +4,13 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
-
 import java.util.Locale;
 
 public class LocaleManager {
 
     private static String language;
 
-    public static void setLanguange(String newLanguage) {
+    public static void setLanguage(String newLanguage) {
         language = newLanguage;
     }
 
@@ -22,7 +21,9 @@ public class LocaleManager {
     }
 
     public static Context updateResources(Context context) {
+
         Locale locale = new Locale(getLanguage());
+        locale = zhCheck(locale);
         Locale.setDefault(locale);
 
         Resources res = context.getResources();
@@ -35,5 +36,31 @@ public class LocaleManager {
             res.updateConfiguration(config, res.getDisplayMetrics());
         }
         return context;
+    }
+
+    private static Locale zhCheck(Locale newLocaleLanguage) {
+        final String ZH = "zh";
+        final String TW = "TW";
+        final String CN = "CN";
+
+        Locale mLocale;
+        String mNewLocaleLanguage = String.valueOf(newLocaleLanguage);
+
+        if (mNewLocaleLanguage.length() == 5) {
+            mLocale = new Locale(
+                    mNewLocaleLanguage.substring(0, 2),
+                    mNewLocaleLanguage.substring(3, 5).toUpperCase()
+            );
+            return mLocale;
+        } else if (mNewLocaleLanguage.equals(ZH)) {
+            if (Locale.getDefault().getCountry().equals(TW)) {
+                mLocale = new Locale(ZH, TW);
+            } else {
+                mLocale = new Locale(ZH, CN);
+            }
+            return mLocale;
+        } else {
+            return newLocaleLanguage;
+        }
     }
 }


### PR DESCRIPTION
Fix Locale Manager getLanguage() issue, 
If devices in Taiwan or Hong Kong area, 
it's the language code should be zh-TW or zh-HK.