### PR TITLE
Fix Error : Pick Image CameraOnly on Android Q

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,15 +4,15 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }
 
 ext {
     sdk = [
-            compileSdk: 28,
-            targetSdk : 28,
+            compileSdk: 29,
+            targetSdk : 29,
             minSdk    : 14
     ]
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 20 03:29:47 EEST 2019
+#Wed Mar 04 09:56:13 WIB 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/imagepicker/build.gradle
+++ b/imagepicker/build.gradle
@@ -43,11 +43,8 @@ artifacts {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-
-    implementation "com.github.bumptech.glide:glide:4.9.0"
-
-    implementation "androidx.recyclerview:recyclerview:1.0.0"
+    implementation "com.github.bumptech.glide:glide:4.10.0"
+    implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.appcompat:appcompat:1.1.0"
-
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
 }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/DefaultCameraModule.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/DefaultCameraModule.java
@@ -29,7 +29,7 @@ public class DefaultCameraModule implements CameraModule, Serializable {
     @Override
     public Intent getCameraIntent(Context context, BaseConfig config) {
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
-        File imageFile = ImagePickerUtils.createImageFile(config.getImageDirectory());
+        File imageFile = ImagePickerUtils.createImageFile(config.getImageDirectory(), context);
         if (imageFile != null) {
             Context appContext = context.getApplicationContext();
             String providerName = String.format(Locale.ENGLISH, "%s%s", appContext.getPackageName(), ".imagepicker.provider");

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -34,8 +34,8 @@ repositories {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    implementation "com.github.bumptech.glide:glide:4.9.0"
-    implementation "androidx.appcompat:appcompat:1.0.2"
+    implementation "com.github.bumptech.glide:glide:4.10.0"
+    implementation "androidx.appcompat:appcompat:1.1.0"
 
     /* Development */
     implementation project(':rximagepicker')


### PR DESCRIPTION
- Environment.getExternalStoragePublicDirectory is now deprecated on
Android Q.
- On Android Q cameraOnly is always getting error
"Failed to create image file" with blank white space screen.