### PR TITLE
fix snackbar: snackbar shows below image's recycler view

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/view/SnackBarView.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/view/SnackBarView.java
@@ -1,15 +1,16 @@
 package com.esafirm.imagepicker.view;
 
 import android.content.Context;
-import androidx.annotation.StringRes;
-import androidx.core.view.ViewCompat;
-import androidx.interpolator.view.animation.FastOutLinearInInterpolator;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.animation.Interpolator;
 import android.widget.Button;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+
+import androidx.annotation.StringRes;
+import androidx.core.view.ViewCompat;
+import androidx.interpolator.view.animation.FastOutLinearInInterpolator;
 
 import com.esafirm.imagepicker.R;
 
@@ -43,9 +44,6 @@ public class SnackBarView extends RelativeLayout {
         int height = getContext().getResources().getDimensionPixelSize(R.dimen.ef_height_snackbar);
         ViewCompat.setTranslationY(this, height);
         ViewCompat.setAlpha(this, 0f);
-
-        int padding = getContext().getResources().getDimensionPixelSize(R.dimen.ef_spacing_double);
-        setPadding(padding, 0, padding, 0);
 
         txtCaption = (TextView) findViewById(R.id.ef_snackbar_txt_bottom_caption);
         btnAction = (Button) findViewById(R.id.ef_snackbar_btn_action);

--- a/imagepicker/src/main/res/layout/ef_fragment_image_picker.xml
+++ b/imagepicker/src/main/res/layout/ef_fragment_image_picker.xml
@@ -20,16 +20,16 @@
         android:layout_centerInParent="true"
         android:visibility="gone"/>
 
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
     <com.esafirm.imagepicker.view.SnackBarView
         android:id="@+id/ef_snackbar"
         android:layout_width="match_parent"
         android:layout_height="56dp"
         android:layout_alignBottom="@+id/recyclerView"
-        android:layout_alignParentBottom="true"
-        android:background="@color/ef_black_alpha_aa"/>
+        android:layout_alignParentBottom="true"/>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
 </RelativeLayout>

--- a/imagepicker/src/main/res/layout/ef_imagepikcer_snackbar.xml
+++ b/imagepicker/src/main/res/layout/ef_imagepikcer_snackbar.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/ef_height_snackbar"
+    android:background="@color/ef_black_alpha_aa"
+    android:paddingStart="@dimen/ef_spacing_double"
+    android:paddingEnd="@dimen/ef_spacing_double"
     tools:parentTag="RelativeLayout">
 
     <TextView
@@ -27,4 +29,5 @@
         android:background="?selectableItemBackground"
         android:textColor="?colorAccent"
         tools:text="@string/ef_ok"/>
-</merge>
+
+</RelativeLayout>


### PR DESCRIPTION
**Description:**
When user click to photo icon on toolbar the snackbar isn't showing correctly, if camera permission had been denied earlier.

**Resolution**
Put snackbar over image's recyclerview

