### PR TITLE
Show the video duration on the image picker.

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/ImagePickerAdapter.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/ImagePickerAdapter.java
@@ -19,7 +19,9 @@ import com.esafirm.imagepicker.listeners.OnImageClickListener;
 import com.esafirm.imagepicker.listeners.OnImageSelectedListener;
 import com.esafirm.imagepicker.model.Image;
 
+import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class ImagePickerAdapter extends BaseListAdapter<ImagePickerAdapter.ImageViewHolder> {
@@ -29,6 +31,8 @@ public class ImagePickerAdapter extends BaseListAdapter<ImagePickerAdapter.Image
 
     private OnImageClickListener itemClickListener;
     private OnImageSelectedListener imageSelectedListener;
+
+    private HashMap<Long, String> videoDurationHolder = new HashMap<>();
 
     public ImagePickerAdapter(Context context, ImageLoader imageLoader,
                               List<Image> selectedImages, OnImageClickListener itemClickListener) {
@@ -67,7 +71,12 @@ public class ImagePickerAdapter extends BaseListAdapter<ImagePickerAdapter.Image
             showFileTypeIndicator = true;
         }
         if (ImagePickerUtils.isVideoFormat(image)) {
-            fileTypeLabel = getContext().getResources().getString(R.string.ef_video);
+            if (videoDurationHolder.containsKey(image.getId())) {
+                fileTypeLabel = videoDurationHolder.get(image.getId());
+            } else {
+                fileTypeLabel = ImagePickerUtils.getVideoDurationLabel(getContext(), new File(image.getPath()));
+                videoDurationHolder.put(image.getId(), fileTypeLabel);
+            }
             showFileTypeIndicator = true;
         }
         viewHolder.fileTypeIndicator.setText(fileTypeLabel);

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/helper/ImagePickerUtils.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/helper/ImagePickerUtils.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.media.MediaMetadataRetriever;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -106,7 +107,21 @@ public class ImagePickerUtils {
                 ? URLConnection.guessContentTypeFromName(image.getPath())
                 : MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
         return mimeType != null && mimeType.startsWith("video");
+    }
 
+    public static String getVideoDurationLabel(Context context, File file) {
+        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+        retriever.setDataSource(context, Uri.fromFile(file));
+        Long duration = Long.parseLong(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION));
+        retriever.release();
+        long second = (duration / 1000) % 60;
+        long minute = (duration / (1000 * 60)) % 60;
+        long hour = (duration / (1000 * 60 * 60)) % 24;
+        if (hour > 0) {
+            return String.format("%02d:%02d:%02d", hour, minute, second);
+        } else {
+            return String.format("%02d:%02d", minute, second);
+        }
     }
 
     private static String getExtension(String path) {

--- a/imagepicker/src/main/res/values-da/strings.xml
+++ b/imagepicker/src/main/res/values-da/strings.xml
@@ -24,7 +24,6 @@
 
     <!--Don't Translate-->
     <string name="ef_gif" translatable="false">GIF</string>
-    <string name="ef_video" translatable="false">Video</string>
     <string name="ef_content_desc_folder" translatable="false">Folder</string>
     <string name="ef_content_desc_image" translatable="false">Image</string>
 

--- a/imagepicker/src/main/res/values-de/strings.xml
+++ b/imagepicker/src/main/res/values-de/strings.xml
@@ -24,7 +24,6 @@
 
     <!--Don't Translate-->
     <string name="ef_gif" translatable="false">GIF</string>
-    <string name="ef_video" translatable="false">Video</string>
     <string name="ef_content_desc_folder" translatable="false">Folder</string>
     <string name="ef_content_desc_image" translatable="false">Image</string>
 

--- a/imagepicker/src/main/res/values/strings.xml
+++ b/imagepicker/src/main/res/values/strings.xml
@@ -24,7 +24,6 @@
 
     <!--Don't Translate-->
     <string name="ef_gif" translatable="false">GIF</string>
-    <string name="ef_video" translatable="false">Video</string>
     <string name="ef_content_desc_folder" translatable="false">Folder</string>
     <string name="ef_content_desc_image" translatable="false">Image</string>
 


### PR DESCRIPTION
- Show the duration label as HH:mm:ss or mm:ss format.

https://github.com/esafirm/android-image-picker/issues/270