### PR TITLE
Sort folders by date added

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/imageloader/DefaultImageLoader.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/imageloader/DefaultImageLoader.java
@@ -1,13 +1,5 @@
 package com.esafirm.imagepicker.features.imageloader;
 
-import java.io.InputStream;
-import java.io.IOException;
-
-import android.content.ContentResolver;
-import android.graphics.Matrix;
-import android.media.ExifInterface;
-import android.net.Uri;
-import android.util.Log;
 import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
@@ -17,13 +9,11 @@ import com.esafirm.imagepicker.R;
 import com.esafirm.imagepicker.model.Image;
 
 public class DefaultImageLoader implements ImageLoader {
-    private static final String TAG = "ImagePicker";
 
     @Override
     public void loadImage(Image image, ImageView imageView, ImageType imageType) {
-        Uri uri = image.getUri();
         Glide.with(imageView.getContext())
-                .load(uri)
+                .load(image.getUri())
                 .apply(RequestOptions
                         .placeholderOf(imageType == ImageType.FOLDER
                                 ? R.drawable.ef_folder_placeholder
@@ -34,35 +24,5 @@ public class DefaultImageLoader implements ImageLoader {
                 )
                 .transition(DrawableTransitionOptions.withCrossFade())
                 .into(imageView);
-        InputStream inputStream;
-        try {
-          inputStream = imageView.getContext()
-            .getContentResolver()
-            .openInputStream(uri);
-          ExifInterface exif = new ExifInterface(inputStream);
-          int orientation = exif.getAttributeInt(
-            ExifInterface.TAG_ORIENTATION,
-            ExifInterface.ORIENTATION_NORMAL);
-          inputStream.close();
-          imageView.setRotation(getDegrees(orientation));
-        } catch (IOException e) {
-          Log.e(TAG, e.toString());
-        }
-    }
-
-    public float getDegrees(int orientation) {
-        float degrees = 0;
-        switch (orientation) {
-            case ExifInterface.ORIENTATION_ROTATE_180:
-                degrees = 180;
-                break;
-            case ExifInterface.ORIENTATION_ROTATE_90:
-                degrees = 90;
-                break;
-            case ExifInterface.ORIENTATION_ROTATE_270:
-                degrees = -90;
-                break;
-        }
-        return degrees;
     }
 }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/imageloader/DefaultImageLoader.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/imageloader/DefaultImageLoader.java
@@ -1,5 +1,13 @@
 package com.esafirm.imagepicker.features.imageloader;
 
+import java.io.InputStream;
+import java.io.IOException;
+
+import android.content.ContentResolver;
+import android.graphics.Matrix;
+import android.media.ExifInterface;
+import android.net.Uri;
+import android.util.Log;
 import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
@@ -9,11 +17,13 @@ import com.esafirm.imagepicker.R;
 import com.esafirm.imagepicker.model.Image;
 
 public class DefaultImageLoader implements ImageLoader {
+    private static final String TAG = "ImagePicker";
 
     @Override
     public void loadImage(Image image, ImageView imageView, ImageType imageType) {
+        Uri uri = image.getUri();
         Glide.with(imageView.getContext())
-                .load(image.getUri())
+                .load(uri)
                 .apply(RequestOptions
                         .placeholderOf(imageType == ImageType.FOLDER
                                 ? R.drawable.ef_folder_placeholder
@@ -24,5 +34,35 @@ public class DefaultImageLoader implements ImageLoader {
                 )
                 .transition(DrawableTransitionOptions.withCrossFade())
                 .into(imageView);
+        InputStream inputStream;
+        try {
+          inputStream = imageView.getContext()
+            .getContentResolver()
+            .openInputStream(uri);
+          ExifInterface exif = new ExifInterface(inputStream);
+          int orientation = exif.getAttributeInt(
+            ExifInterface.TAG_ORIENTATION,
+            ExifInterface.ORIENTATION_NORMAL);
+          inputStream.close();
+          imageView.setRotation(getDegrees(orientation));
+        } catch (IOException e) {
+          Log.e(TAG, e.toString());
+        }
+    }
+
+    public float getDegrees(int orientation) {
+        float degrees = 0;
+        switch (orientation) {
+            case ExifInterface.ORIENTATION_ROTATE_180:
+                degrees = 180;
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_90:
+                degrees = 90;
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_270:
+                degrees = -90;
+                break;
+        }
+        return degrees;
     }
 }


### PR DESCRIPTION
Currently the `folderMode` isn't as useful as it could be. Folders are sorted in whatever order the HashMap happens to produce from the `values()` call. It doesn't result in a great user experience if the user has several albums.

This change has it sort the folders by the dates the photos were added, in order of newest to oldest.