### PR TITLE
fix crash from previous PR #298

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/view/SquareFrameLayout.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/view/SquareFrameLayout.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.FrameLayout
 
-class SquareFrameLayout(
+class SquareFrameLayout @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0

--- a/rximagepicker/src/main/java/com/esafirm/rximagepicker/ShadowActivity.kt
+++ b/rximagepicker/src/main/java/com/esafirm/rximagepicker/ShadowActivity.kt
@@ -16,7 +16,7 @@ class ShadowActivity : Activity() {
         startActivityForResult(intent, RC_IMAGE_PICKER)
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent) {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         val images = ImagePicker.getImages(data)
         RxImagePicker.instance.onHandleResult(images)
         finish()


### PR DESCRIPTION
fix crash from previous PR #298

- layout inflating crash due to kotlin code without `@JvmOverload`
- activity result crash due to null data