### PR TITLE
Fix incorrect image dimensions on Android 11

### DIFF
--- a/imagepicker/src/main/res/layout/ef_imagepicker_item_image.xml
+++ b/imagepicker/src/main/res/layout/ef_imagepicker_item_image.xml
@@ -11,6 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:contentDescription="@string/ef_content_desc_image"
+        android:adjustViewBounds="true"
         android:scaleType="centerCrop"/>
 
     <View


### PR DESCRIPTION
First, thanks for the amazing library! 🙇 💪 
Second, It seems like image dimensions are incorrect on Android 11, this is a pretty straight forward fix.

#### To reproduce
* Run the sample app on a device with Android 11
* Tap 'Launch Fragment'
* Select a folder → 🐛

| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20201013-143756](https://user-images.githubusercontent.com/12352397/95856331-87216180-0d62-11eb-90ce-f202aab29288.jpg)  | ![Screenshot_20201013-143731](https://user-images.githubusercontent.com/12352397/95856300-7cff6300-0d62-11eb-9e3e-8ffb60097533.jpg) |



