### PR TITLE
Use Context#deleteFile for local/private storage

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.java
@@ -408,7 +408,7 @@ public class ImagePickerFragment extends Fragment implements ImagePickerView {
             if (resultCode == RESULT_OK) {
                 presenter.finishCaptureImage(getActivity(), data, getBaseConfig());
             } else if (resultCode == RESULT_CANCELED && isCameraOnly) {
-                presenter.abortCaptureImage();
+                presenter.abortCaptureImage(requireContext());
                 interactionListener.cancel();
             }
         }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.java
@@ -121,8 +121,8 @@ class ImagePickerPresenter extends BasePresenter<ImagePickerView> {
         });
     }
 
-    void abortCaptureImage() {
-        getCameraModule().removeImage();
+    void abortCaptureImage(Context context) {
+        getCameraModule().removeImage(context);
     }
 
     private void runOnUiIfAvailable(Runnable runnable) {

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/CameraModule.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/CameraModule.kt
@@ -7,5 +7,5 @@ import com.esafirm.imagepicker.features.common.BaseConfig
 interface CameraModule {
     fun getCameraIntent(context: Context, config: BaseConfig): Intent?
     fun getImage(context: Context, intent: Intent?, imageReadyListener: OnImageReadyListener?)
-    fun removeImage()
+    fun removeImage(context: Context)
 }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/DefaultCameraModule.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/DefaultCameraModule.kt
@@ -94,11 +94,11 @@ class DefaultCameraModule : CameraModule, Serializable {
         }
     }
 
-    override fun removeImage() {
+    override fun removeImage(context: Context) {
         val imagePath = currentImagePath ?: return
         val file = File(imagePath)
         if (file.exists()) {
-            file.delete()
+            context.deleteFile(file.name)
         }
     }
 }


### PR DESCRIPTION
mASAPP Report is reporting the following error:
```Unsafe file delete
Category: Code Quality
CVSS: 4.7
Description: The use of the method "java.io/File/delete" deletes the file or directory denoted by
its abstract pathname. If this pathname denotes a directory, then the directory must be empty
in order to be deleted.
Impact: This may lead to information disclosure if the deleted file was stored in an external SD
card. The original file could be recovered by a third-party in an undesired manner.
Recommendations: Please make sure not to use file.delete to delete essential files. Use
Context.deleteFile for private files instead.
```