### PR TITLE
Use READ_EXTERNAL_STORAGE instead of WRITE on android11.

### DIFF
--- a/imagepicker/src/main/AndroidManifest.xml
+++ b/imagepicker/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="com.esafirm.imagepicker">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.CAMERA" />
 
     <application>

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/helper/ImagePickerPreferences.java
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/helper/ImagePickerPreferences.java
@@ -6,7 +6,7 @@ import android.preference.PreferenceManager;
 
 public class ImagePickerPreferences {
 
-    public static final String PREF_WRITE_EXTERNAL_STORAGE_REQUESTED = "writeExternalRequested";
+    public static final String PREF_EXTERNAL_STORAGE_REQUESTED = "writeExternalRequested";
     public static final String PREF_CAMERA_REQUESTED = "cameraRequested";
 
     private Context context;

--- a/imagepicker/src/main/res/values-ar/strings.xml
+++ b/imagepicker/src/main/res/values-ar/strings.xml
@@ -18,7 +18,7 @@
     <string name="ef_error_null_cursor">عذراً، هناك خطأ ما!</string>
 
     <string name="ef_msg_empty_images">لم يتم العثور على صور</string>
-    <string name="ef_msg_no_write_external_permission">عليك إعطاء التطبيق الصلاحية لاستخدام الصور</string>
+    <string name="ef_msg_no_external_permission">عليك إعطاء التطبيق الصلاحية لاستخدام الصور</string>
     <string name="ef_msg_no_camera_permission">عليك إعطاء التطبيق الصلاحية لاستخدام الكاميرا لتتمكن من التصوير</string>
     <string name="ef_msg_limit_images">تحديد إختيار الصور</string>
 </resources>

--- a/imagepicker/src/main/res/values-da/strings.xml
+++ b/imagepicker/src/main/res/values-da/strings.xml
@@ -18,7 +18,7 @@
     <string name="ef_error_null_cursor">Beklager, der er sket en fejl!</string>
 
     <string name="ef_msg_empty_images">Ingen billeder fundet</string>
-    <string name="ef_msg_no_write_external_permission">Giv tilladelse til at vælge billeder fra telefon hukkommelsen</string>
+    <string name="ef_msg_no_external_permission">Giv tilladelse til at vælge billeder fra telefon hukkommelsen</string>
     <string name="ef_msg_no_camera_permission">Giv tilladelse til kamera til at tage billeder</string>
     <string name="ef_msg_limit_images">Der kan ikke vælges flere billeder</string>
 

--- a/imagepicker/src/main/res/values-de/strings.xml
+++ b/imagepicker/src/main/res/values-de/strings.xml
@@ -18,7 +18,7 @@
     <string name="ef_error_null_cursor">Ups, da ist was schiefgegangen!</string>
 
     <string name="ef_msg_empty_images">Keine Bilder gefunden</string>
-    <string name="ef_msg_no_write_external_permission">Bitte erlaube Zugriff auf den Speicher um Bilder auszuwählen</string>
+    <string name="ef_msg_no_external_permission">Bitte erlaube Zugriff auf den Speicher um Bilder auszuwählen</string>
     <string name="ef_msg_no_camera_permission">Bitte erlaube Zugriff auf die Kamera um Bilder aufzunehmen</string>
     <string name="ef_msg_limit_images">Maximale Anzahl Bilder erreicht</string>
 

--- a/imagepicker/src/main/res/values-fr/strings.xml
+++ b/imagepicker/src/main/res/values-fr/strings.xml
@@ -18,7 +18,7 @@
     <string name="ef_error_null_cursor">Oups, quelque chose s\'est mal déroulé!</string>
 
     <string name="ef_msg_empty_images">Aucune image trouvée</string>
-    <string name="ef_msg_no_write_external_permission">L\'application nécessite l\'autorisation de stockage pour afficher les images</string>
+    <string name="ef_msg_no_external_permission">L\'application nécessite l\'autorisation de stockage pour afficher les images</string>
     <string name="ef_msg_no_camera_permission">L\'application nécessite l\'autorisation de la caméra</string>
     <string name="ef_msg_limit_images">Limite du nombre d\'images</string>
 

--- a/imagepicker/src/main/res/values-in/strings.xml
+++ b/imagepicker/src/main/res/values-in/strings.xml
@@ -18,7 +18,7 @@
     <string name="ef_error_null_cursor">Ups, ada yang tidak beres!</string>
 
     <string name="ef_msg_empty_images">Gambar tidak ditemukan</string>
-    <string name="ef_msg_no_write_external_permission">Mohon berikan izin terhadap penyimpanan untuk memilih gambar</string>
+    <string name="ef_msg_no_external_permission">Mohon berikan izin terhadap penyimpanan untuk memilih gambar</string>
     <string name="ef_msg_no_camera_permission">Mohon berikan izin terhadap kamera untuk mengambil gambar</string>
     <string name="ef_msg_limit_images">Gambar yang terpilih sudah mencapai batas maksimal</string>
 </resources>

--- a/imagepicker/src/main/res/values-it/strings.xml
+++ b/imagepicker/src/main/res/values-it/strings.xml
@@ -17,7 +17,7 @@
     <string name="ef_error_null_cursor">Oops, qualcosa è andato storto!</string>
 
     <string name="ef_msg_empty_images">Nessuna immagine trovata</string>
-    <string name="ef_msg_no_write_external_permission">Dai il permesso per poter selezionare le immagini</string>
+    <string name="ef_msg_no_external_permission">Dai il permesso per poter selezionare le immagini</string>
     <string name="ef_msg_no_camera_permission">Dai il permesso per poter scattare una foto</string>
     <string name="ef_msg_limit_images">Hai raggiunto il limite massimo di selezione</string>
     <string name="ef_ltitle_permission_denied">Permesso negato</string>

--- a/imagepicker/src/main/res/values-ja/strings.xml
+++ b/imagepicker/src/main/res/values-ja/strings.xml
@@ -16,7 +16,7 @@
     <string name="ef_error_null_cursor">エラーが発生しました</string>
 
     <string name="ef_msg_empty_images">画像が見つかりません</string>
-    <string name="ef_msg_no_write_external_permission">端末のファイルへのアクセスを許可してください</string>
+    <string name="ef_msg_no_external_permission">端末のファイルへのアクセスを許可してください</string>
     <string name="ef_msg_no_camera_permission">端末のカメラへのアクセスを許可してください</string>
     <string name="ef_msg_limit_images">選択できる画像の上限です</string>
     <string name="ef_ltitle_permission_denied">権限がありません</string>

--- a/imagepicker/src/main/res/values-ko/strings.xml
+++ b/imagepicker/src/main/res/values-ko/strings.xml
@@ -18,7 +18,7 @@
     <string name="ef_error_null_cursor">알 수 없는 오류가 발생하였습니다.</string>
 
     <string name="ef_msg_empty_images">이미지가 비어있음</string>
-    <string name="ef_msg_no_write_external_permission">이미지를 불러오기 위해 저장공간 권한을 허용해주세요</string>
+    <string name="ef_msg_no_external_permission">이미지를 불러오기 위해 저장공간 권한을 허용해주세요</string>
     <string name="ef_msg_no_camera_permission">사진을 찍기위해 카메라 권한을 허용해주세요</string>
     <string name="ef_msg_limit_images">이미지 선택 제한 초과</string>
 

--- a/imagepicker/src/main/res/values-pt-rBR/strings.xml
+++ b/imagepicker/src/main/res/values-pt-rBR/strings.xml
@@ -18,7 +18,7 @@
     <string name="ef_error_null_cursor">Ops, algo deu errado!</string>
 
     <string name="ef_msg_empty_images">Nenhuma imagem encontrada</string>
-    <string name="ef_msg_no_write_external_permission">Por favor dê permissão ao armazenamento para selecionar as imagens</string>
+    <string name="ef_msg_no_external_permission">Por favor dê permissão ao armazenamento para selecionar as imagens</string>
     <string name="ef_msg_no_camera_permission">Por favor dê permissão à câmera para tirar fotos</string>
     <string name="ef_msg_limit_images">Limite de imagens atingido</string>
 

--- a/imagepicker/src/main/res/values-ro/strings.xml
+++ b/imagepicker/src/main/res/values-ro/strings.xml
@@ -17,7 +17,7 @@
     <string name="ef_error_null_cursor">Hopa, ceva a mers prost!</string>
 
     <string name="ef_msg_empty_images">Nu am găsit imaginea</string>
-    <string name="ef_msg_no_write_external_permission">Vă rugăm să acordați permisiunea de stocare pentru a selecta imagini</string>
+    <string name="ef_msg_no_external_permission">Vă rugăm să acordați permisiunea de stocare pentru a selecta imagini</string>
     <string name="ef_msg_no_camera_permission">Vă rugăm să acordați permisiunea fotocamerei pentru a captura imagini</string>
     <string name="ef_msg_limit_images">Limita de selecție a imaginii depăşită</string>
     <string name="ef_ltitle_permission_denied">Acces refuzat</string>

--- a/imagepicker/src/main/res/values-ru/strings.xml
+++ b/imagepicker/src/main/res/values-ru/strings.xml
@@ -13,7 +13,7 @@
     <string name="ef_error_no_camera">Камера недоступна</string>
     <string name="ef_error_null_cursor">Ой! Что-то пошло не так!</string>
     <string name="ef_msg_empty_images">Изображений не найдено</string>
-    <string name="ef_msg_no_write_external_permission">Пожалуйста, разрешите доступ к хранилищу, чтобы выбрать изображения</string>
+    <string name="ef_msg_no_external_permission">Пожалуйста, разрешите доступ к хранилищу, чтобы выбрать изображения</string>
     <string name="ef_msg_no_camera_permission">Пожалуйста, разрешите доступ к камере, чтобы сделать снимок</string>
     <string name="ef_msg_limit_images">Лимит выбора изображений</string>
 </resources>

--- a/imagepicker/src/main/res/values-tr/strings.xml
+++ b/imagepicker/src/main/res/values-tr/strings.xml
@@ -17,7 +17,7 @@
     <string name="ef_error_null_cursor">Hoop! Birşeyler yanlış gitti!</string>
 
     <string name="ef_msg_empty_images">Resimler bulunamadı</string>
-    <string name="ef_msg_no_write_external_permission">Lütfen resim seçmek için depolama iznini verin</string>
+    <string name="ef_msg_no_external_permission">Lütfen resim seçmek için depolama iznini verin</string>
     <string name="ef_msg_no_camera_permission">Resim çekmek için lütfen kamera iznini verin</string>
     <string name="ef_msg_limit_images">Resim seçimi sınırı</string>
 </resources>

--- a/imagepicker/src/main/res/values-uk/strings.xml
+++ b/imagepicker/src/main/res/values-uk/strings.xml
@@ -13,7 +13,7 @@
     <string name="ef_error_no_camera">Камера недоступна</string>
     <string name="ef_error_null_cursor">Ой! Щось пішло не так!</string>
     <string name="ef_msg_empty_images">Зображень не знайдено</string>
-    <string name="ef_msg_no_write_external_permission">Будь ласка, дозвольте доступ до сховища, щоб обрати зображення</string>
+    <string name="ef_msg_no_external_permission">Будь ласка, дозвольте доступ до сховища, щоб обрати зображення</string>
     <string name="ef_msg_no_camera_permission">Будь ласка, дозвольте доступ до камери, щоб зробити знімок</string>
     <string name="ef_msg_limit_images">Ліміт вибору зображень</string>
 </resources>

--- a/imagepicker/src/main/res/values-zh-rCN/strings.xml
+++ b/imagepicker/src/main/res/values-zh-rCN/strings.xml
@@ -16,7 +16,7 @@
     <string name="ef_error_null_cursor">啊哦，发生错误！</string>
 
     <string name="ef_msg_empty_images">找不到照片</string>
-    <string name="ef_msg_no_write_external_permission">请给予存取外部存储权限以选择照片</string>
+    <string name="ef_msg_no_external_permission">请给予存取外部存储权限以选择照片</string>
     <string name="ef_msg_no_camera_permission">请给予获取相机权限以拍摄照片</string>
     <string name="ef_msg_limit_images">已达到最多选择照片数量</string>
     <string name="ef_ltitle_permission_denied">没有权限</string>

--- a/imagepicker/src/main/res/values-zh-rTW/strings.xml
+++ b/imagepicker/src/main/res/values-zh-rTW/strings.xml
@@ -16,7 +16,7 @@
     <string name="ef_error_null_cursor">噢，發生問題</string>
 
     <string name="ef_msg_empty_images">找不到相片</string>
-    <string name="ef_msg_no_write_external_permission">請允許存取外部存儲以選擇相片</string>
+    <string name="ef_msg_no_external_permission">請允許存取外部存儲以選擇相片</string>
     <string name="ef_msg_no_camera_permission">請允許存取相機以拍攝相片</string>
     <string name="ef_msg_limit_images">已達到最多選擇相片數量</string>
     <string name="ef_ltitle_permission_denied">沒有權限</string>

--- a/imagepicker/src/main/res/values/strings.xml
+++ b/imagepicker/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="ef_error_null_cursor">Oops, something went wrong!</string>
 
     <string name="ef_msg_empty_images">No images found</string>
-    <string name="ef_msg_no_write_external_permission">Please grant storage permission to select images</string>
+    <string name="ef_msg_no_external_permission">Please grant storage permission to select images</string>
     <string name="ef_msg_no_camera_permission">Please grant camera permission to capture image</string>
     <string name="ef_msg_limit_images">Image selection limit</string>
 


### PR DESCRIPTION
In android11 "write_external_storage" permission is ignored. 
So I change to use "read" permission instead of "write" on scoped storage devices. 

Related 
https://github.com/esafirm/android-image-picker/issues/361, https://github.com/esafirm/android-image-picker/issues/341
