### PR TITLE
fix fragment not attached to context exception

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerLauncher.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerLauncher.kt
@@ -30,9 +30,10 @@ class ImagePickerLauncher(
 typealias ImagePickerCallback = (List<Image>) -> Unit
 
 fun Fragment.registerImagePicker(
+    context: Context,
     callback: ImagePickerCallback
 ): ImagePickerLauncher {
-    return ImagePickerLauncher(requireContext(), createLauncher(callback))
+    return ImagePickerLauncher(context, createLauncher(callback))
 }
 
 fun ComponentActivity.registerImagePicker(

--- a/sample/src/main/java/com/esafirm/sample/CustomUIActivity.kt
+++ b/sample/src/main/java/com/esafirm/sample/CustomUIActivity.kt
@@ -134,7 +134,7 @@ class CustomUIActivity : AppCompatActivity() {
     }
 
     private fun setupView() {
-        setSupportActionBar(binding.toolbar as Toolbar)
+        setSupportActionBar(binding.toolbar.root as Toolbar)
         checkNotNull(supportActionBar)
 
         actionBar = supportActionBar!!

--- a/sample/src/main/java/com/esafirm/sample/MainFragment.kt
+++ b/sample/src/main/java/com/esafirm/sample/MainFragment.kt
@@ -1,24 +1,27 @@
 package com.esafirm.sample
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import com.bumptech.glide.Glide
-import com.esafirm.imagepicker.features.ImagePickerConfig
-import com.esafirm.imagepicker.features.ImagePickerMode
-import com.esafirm.imagepicker.features.ReturnMode
-import com.esafirm.imagepicker.features.registerImagePicker
+import com.esafirm.imagepicker.features.*
 import com.esafirm.sample.databinding.FragmentMainBinding
 
 class MainFragment : Fragment(R.layout.fragment_main) {
 
     private lateinit var binding: FragmentMainBinding
 
-    private val imagePickerLauncher = registerImagePicker {
-        val firstImage = it.firstOrNull() ?: return@registerImagePicker
-        Glide.with(binding.imgFragment)
-            .load(firstImage.uri)
-            .into(binding.imgFragment)
+    private lateinit var imagePickerLauncher: ImagePickerLauncher
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        imagePickerLauncher = registerImagePicker(context) {
+            val firstImage = it.firstOrNull() ?: return@registerImagePicker
+            Glide.with(binding.imgFragment)
+                .load(firstImage.uri)
+                .into(binding.imgFragment)
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
- The application crash because the fragment is not attached to context yet when initializing ImagePickerLauncher 