### PR TITLE
Allows user to set the selected image overlay via the theme.

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/ImagePickerAdapter.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/adapter/ImagePickerAdapter.kt
@@ -3,6 +3,7 @@ package com.esafirm.imagepicker.adapter
 import android.content.Context
 import android.net.Uri
 import android.provider.MediaStore
+import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -94,10 +95,12 @@ class ImagePickerAdapter(
                     addSelected(image, position)
                 }
             }
-            container?.foreground = if (isSelected) ContextCompat.getDrawable(
-                context,
-                R.drawable.ef_ic_done_white
-            ) else null
+            container?.foreground = if (isSelected) {
+                val typedValue = TypedValue()
+                context.theme.resolveAttribute(R.attr.ef_selected_image_overlay, typedValue, true)
+                val imageResId = typedValue.resourceId
+                ContextCompat.getDrawable(context, imageResId) ?: throw IllegalArgumentException("Cannot load drawable $imageResId")
+            } else null
         }
     }
 

--- a/imagepicker/src/main/res/values/attrs.xml
+++ b/imagepicker/src/main/res/values/attrs.xml
@@ -1,0 +1,3 @@
+<resources>
+    <attr name="ef_selected_image_overlay" format="reference" />
+</resources>

--- a/imagepicker/src/main/res/values/styles.xml
+++ b/imagepicker/src/main/res/values/styles.xml
@@ -10,6 +10,7 @@
         <item name="colorPrimary">@color/ef_colorPrimary</item>
         <item name="colorPrimaryDark">@color/ef_colorPrimaryDark</item>
         <item name="colorAccent">@color/ef_colorAccent</item>
+        <item name="ef_selected_image_overlay">@drawable/ef_ic_done_white</item>
     </style>
 
     <style name="ef_CustomToolbarTheme" parent="Base.ThemeOverlay.AppCompat.ActionBar">


### PR DESCRIPTION
This change allows users to configure the drawable that is used to show when an image is selected (currently a checkmark) via the theme.