### PR TITLE
Add permission check for android13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ buildscript {
 
 ext {
     sdk = [
-            compileSdk: 30,
-            targetSdk : 30,
+            compileSdk: 33,
+            targetSdk : 33,
             minSdk    : 21
     ]
 }

--- a/imagepicker/src/main/AndroidManifest.xml
+++ b/imagepicker/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <application>
         <activity

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     /* Development */
     implementation project(':imagepicker')
 
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
     implementation "androidx.core:core-ktx:$core_ktx_version"
 
     /* UI Test */

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -8,7 +8,9 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.esafirm.sample.MainActivity">
+        <activity
+            android:name="com.esafirm.sample.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
- Closes #403 

## This PR contains
- Set compile and target sdk version 33
  - to use READ_MEDIA_IMAGES permission
- Check READ_MEDIA_IMAGES permission is granted instead of WRITE_EXTERNAL_STORAGE when device is Android13 or later