### PR TITLE
BugFix: Camera pictures are not accessible when storage permission has not been given.

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
@@ -248,7 +248,7 @@ class ImagePickerFragment : Fragment() {
             requireContext(),
             Manifest.permission.WRITE_EXTERNAL_STORAGE
         )
-        if (rc == PackageManager.PERMISSION_GRANTED) {
+        if (rc == PackageManager.PERMISSION_GRANTED || presenter.isCameraCapture) {
             loadData()
         } else {
             requestWriteExternalPermission()

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.kt
@@ -23,6 +23,8 @@ internal class ImagePickerPresenter(
 
     private val cameraModule: CameraModule = ImagePickerComponentsHolder.cameraModule
 
+    var isCameraCapture = false
+
     private val stateObs = LiveDataObservableState(
         ImagePickerState(isLoading = true),
         usePostValue = true
@@ -96,6 +98,7 @@ internal class ImagePickerPresenter(
     }
 
     fun finishCaptureImage(context: Context, data: Intent?, config: BaseConfig?) {
+        isCameraCapture = true
         cameraModule.getImage(context, data) { images ->
             if (ConfigUtils.shouldReturn(config!!, true)) {
                 setState {


### PR DESCRIPTION
### Issue:
Camera pictures are not accessible when storage permission has not been given.

### Description and steps:
Let the user use the camera when storage permission has not been given. Currently, the app lets users open the camera but doesn't let them proceed as storage permission is denied.
Steps:
1. Open image picker functionality
2. Deny storage permission
3. Click on the camera icon
4. Capture the image and proceed further
5. Nothing happens after that

### Expected behavior:
Let the user proceed further with the captured image even when storage permission is denied

### Issue recording:
https://user-images.githubusercontent.com/20037228/196465424-49d6e17e-c267-4721-af81-baeed1856127.mp4

### Fixed issue recording:
https://user-images.githubusercontent.com/20037228/196465874-17e40c15-ed4a-4fbb-803f-44312ee70349.mp4

Please let me know if you have any feedback.
Thank you!