### PR TITLE
BugFix: Image count visible in the folder mode when moved from one folder to another

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 ext {
     sdk = [
             compileSdk: 33,
-            targetSdk : 33,
+            targetSdk : 30,
             minSdk    : 21
     ]
 }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.provider.Settings
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -184,7 +185,10 @@ class ImagePickerFragment : Fragment() {
         resources.configuration.orientation
     ).apply {
         val selectListener = { isSelected: Boolean -> selectImage(isSelected) }
-        val folderClick = { bucket: Folder -> setImageAdapter(bucket.images) }
+        val folderClick = { bucket: Folder ->
+            setImageAdapter(bucket.images)
+            updateTitle()
+        }
 
         setupAdapters(passedSelectedImages, selectListener, folderClick)
         setImageSelectedListener { selectedImages ->

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
@@ -11,7 +11,6 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.provider.Settings
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -33,7 +32,6 @@ import com.esafirm.imagepicker.helper.IpLogger
 import com.esafirm.imagepicker.helper.state.fetch
 import com.esafirm.imagepicker.model.Folder
 import com.esafirm.imagepicker.model.Image
-import java.util.ArrayList
 
 class ImagePickerFragment : Fragment() {
 
@@ -89,9 +87,9 @@ class ImagePickerFragment : Fragment() {
         if (::interactionListener.isInitialized.not()) {
             throw RuntimeException(
                 "ImagePickerFragment needs an " +
-                        "ImagePickerInteractionListener. This will be set automatically if the " +
-                        "activity implements ImagePickerInteractionListener, and can be set manually " +
-                        "with fragment.setInteractionListener(listener)."
+                    "ImagePickerInteractionListener. This will be set automatically if the " +
+                    "activity implements ImagePickerInteractionListener, and can be set manually " +
+                    "with fragment.setInteractionListener(listener)."
             )
         }
 
@@ -277,6 +275,7 @@ class ImagePickerFragment : Fragment() {
             shouldShowRequestPermissionRationale(permission) -> {
                 requestPermissionLauncher.launch(permission)
             }
+
             else -> {
                 if (!preferences.isPermissionRequested()) {
                     preferences.setPermissionIsRequested()
@@ -388,7 +387,6 @@ class ImagePickerFragment : Fragment() {
         private const val STATE_KEY_SELECTED_IMAGES = "Key.SelectedImages"
 
         private const val RC_CAPTURE = 2000
-        private const val RC_PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 23
 
         fun newInstance(config: ImagePickerConfig): ImagePickerFragment {
             val args = Bundle().apply {


### PR DESCRIPTION
### Issue:
Fix the image count issue in the toolbar when the folder mode is selected.

### Description and steps:
Image count is not showing properly in the folder mode when moved from one folder to another.
Steps:
1. Enable folder mode
2. Open Custom Ui image picker
3. Select any number of images and click back
4. Open another folder
5. The toolbar shows "Folder" instead of image count

### Expected behavior:
When opening different folders, the topbar should display the selected image count.

### Issue recording:
https://user-images.githubusercontent.com/20037228/196470226-f54a2796-4598-4a32-91d7-c9d51b55505c.mp4

### Fixed issue recording:
https://user-images.githubusercontent.com/20037228/196470466-0a1a4d63-b9b1-4b55-910c-94151ab75841.mp4


Please let me know if you have any feedback.
Thank you!