### PR TITLE
Enhancement: Start video recording on camera icon clicked when "OnlyVideo" is enabled 

### DIFF
--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.kt
@@ -87,7 +87,9 @@ class ImagePickerActivity : AppCompatActivity(), ImagePickerInteractionListener 
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
         if (!isCameraOnly) {
-            menu.findItem(R.id.menu_camera).isVisible = config?.isShowCamera ?: true
+            menu.findItem(R.id.menu_camera).isVisible =
+                config?.isShowCamera == true && config?.isOnlyVideo == false
+            menu.findItem(R.id.menu_video).isVisible = config?.isShowVideo ?: true
             menu.findItem(R.id.menu_done).apply {
                 title = ConfigUtils.getDoneButtonText(this@ImagePickerActivity, config!!)
                 isVisible = imagePickerFragment.isShowDoneButton
@@ -111,6 +113,10 @@ class ImagePickerActivity : AppCompatActivity(), ImagePickerInteractionListener 
         }
         if (id == R.id.menu_camera) {
             imagePickerFragment.captureImage()
+            return true
+        }
+        if (id == R.id.menu_video) {
+            imagePickerFragment.captureVideo()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerActivity.kt
@@ -89,7 +89,7 @@ class ImagePickerActivity : AppCompatActivity(), ImagePickerInteractionListener 
         if (!isCameraOnly) {
             menu.findItem(R.id.menu_camera).isVisible =
                 config?.isShowCamera == true && config?.isOnlyVideo == false
-            menu.findItem(R.id.menu_video).isVisible = config?.isShowVideo ?: true
+            menu.findItem(R.id.menu_video).isVisible = config?.isShowVideoCamera ?: true
             menu.findItem(R.id.menu_done).apply {
                 title = ConfigUtils.getDoneButtonText(this@ImagePickerActivity, config!!)
                 isVisible = imagePickerFragment.isShowDoneButton

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerComponentsHolder.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerComponentsHolder.kt
@@ -13,6 +13,7 @@ interface ImagePickerComponents {
     val imageLoader: ImageLoader
     val imageFileLoader: ImageFileLoader
     val cameraModule: CameraModule
+    val videoModule: CameraModule
 }
 
 open class DefaultImagePickerComponents(context: Context) : ImagePickerComponents {
@@ -20,6 +21,7 @@ open class DefaultImagePickerComponents(context: Context) : ImagePickerComponent
     override val imageLoader: ImageLoader by lazy { DefaultImageLoader() }
     override val imageFileLoader: ImageFileLoader by lazy { DefaultImageFileLoader(context.applicationContext) }
     override val cameraModule: CameraModule by lazy { DefaultCameraModule() }
+    override val videoModule: CameraModule by lazy { DefaultCameraModule() }
 }
 
 object ImagePickerComponentsHolder : ImagePickerComponents {
@@ -37,6 +39,9 @@ object ImagePickerComponentsHolder : ImagePickerComponents {
 
     override val cameraModule: CameraModule
         get() = internalComponents.cameraModule
+
+    override val videoModule: CameraModule
+        get() = internalComponents.videoModule
 
     fun setInternalComponent(components: ImagePickerComponents) {
         internalComponents = components

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerComponentsHolder.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerComponentsHolder.kt
@@ -13,7 +13,6 @@ interface ImagePickerComponents {
     val imageLoader: ImageLoader
     val imageFileLoader: ImageFileLoader
     val cameraModule: CameraModule
-    val videoModule: CameraModule
 }
 
 open class DefaultImagePickerComponents(context: Context) : ImagePickerComponents {
@@ -21,7 +20,6 @@ open class DefaultImagePickerComponents(context: Context) : ImagePickerComponent
     override val imageLoader: ImageLoader by lazy { DefaultImageLoader() }
     override val imageFileLoader: ImageFileLoader by lazy { DefaultImageFileLoader(context.applicationContext) }
     override val cameraModule: CameraModule by lazy { DefaultCameraModule() }
-    override val videoModule: CameraModule by lazy { DefaultCameraModule() }
 }
 
 object ImagePickerComponentsHolder : ImagePickerComponents {
@@ -39,9 +37,6 @@ object ImagePickerComponentsHolder : ImagePickerComponents {
 
     override val cameraModule: CameraModule
         get() = internalComponents.cameraModule
-
-    override val videoModule: CameraModule
-        get() = internalComponents.videoModule
 
     fun setInternalComponent(components: ImagePickerComponents) {
         internalComponents = components

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.kt
@@ -27,6 +27,7 @@ class ImagePickerConfig(
     override var savePath: ImagePickerSavePath = ImagePickerSavePath.DEFAULT,
     override var returnMode: ReturnMode = ReturnMode.NONE,
     override var isSaveImage: Boolean = true,
+    override var isSaveVideo: Boolean = true,
     var showDoneButtonAlways: Boolean = false
 ) : BaseConfig(), Parcelable {
 

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.kt
@@ -22,7 +22,7 @@ class ImagePickerConfig(
     var isOnlyVideo: Boolean = false,
     var isIncludeAnimation: Boolean = false,
     var isShowCamera: Boolean = true,
-    var isShowVideo: Boolean = true,
+    var isShowVideoCamera: Boolean = false,
     var selectedImages: List<Image> = emptyList(),
     var excludedImages: List<File> = emptyList(),
     override var savePath: ImagePickerSavePath = ImagePickerSavePath.DEFAULT,

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerConfig.kt
@@ -22,6 +22,7 @@ class ImagePickerConfig(
     var isOnlyVideo: Boolean = false,
     var isIncludeAnimation: Boolean = false,
     var isShowCamera: Boolean = true,
+    var isShowVideo: Boolean = true,
     var selectedImages: List<Image> = emptyList(),
     var excludedImages: List<File> = emptyList(),
     override var savePath: ImagePickerSavePath = ImagePickerSavePath.DEFAULT,

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
@@ -324,6 +324,13 @@ class ImagePickerFragment : Fragment() {
         }
     }
 
+    fun captureVideo() {
+        if (!checkCameraAvailability(requireActivity())) {
+            return
+        }
+        presenter.captureVideo(this, config, RC_CAPTURE)
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         presenter.abortLoad()

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
@@ -317,7 +317,11 @@ class ImagePickerFragment : Fragment() {
         if (!checkCameraAvailability(requireActivity())) {
             return
         }
-        presenter.captureImage(this, config, RC_CAPTURE)
+        if (config.isOnlyVideo) {
+            presenter.captureVideo(this, config, RC_CAPTURE)
+        } else{
+            presenter.captureImage(this, config, RC_CAPTURE)
+        }
     }
 
     override fun onDestroy() {

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerFragment.kt
@@ -319,7 +319,7 @@ class ImagePickerFragment : Fragment() {
         }
         if (config.isOnlyVideo) {
             presenter.captureVideo(this, config, RC_CAPTURE)
-        } else{
+        } else {
             presenter.captureImage(this, config, RC_CAPTURE)
         }
     }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.kt
@@ -22,7 +22,7 @@ internal class ImagePickerPresenter(
 ) : ImagePickerAction {
 
     private val cameraModule: CameraModule = ImagePickerComponentsHolder.cameraModule
-
+    private val videoModule: CameraModule = ImagePickerComponentsHolder.videoModule
     private val stateObs = LiveDataObservableState(
         ImagePickerState(isLoading = true),
         usePostValue = true
@@ -84,6 +84,20 @@ internal class ImagePickerPresenter(
     fun captureImage(fragment: Fragment, config: BaseConfig, requestCode: Int) {
         val context = fragment.requireContext().applicationContext
         val intent = cameraModule.getCameraIntent(fragment.requireContext(), config)
+        if (intent == null) {
+            Toast.makeText(
+                context,
+                context.getString(R.string.ef_error_create_image_file),
+                Toast.LENGTH_LONG
+            ).show()
+            return
+        }
+        fragment.startActivityForResult(intent, requestCode)
+    }
+
+    fun captureVideo(fragment: Fragment, config: BaseConfig, requestCode: Int) {
+        val context = fragment.requireContext().applicationContext
+        val intent = videoModule.getVideoIntent(fragment.requireContext(), config)
         if (intent == null) {
             Toast.makeText(
                 context,

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/ImagePickerPresenter.kt
@@ -22,7 +22,6 @@ internal class ImagePickerPresenter(
 ) : ImagePickerAction {
 
     private val cameraModule: CameraModule = ImagePickerComponentsHolder.cameraModule
-    private val videoModule: CameraModule = ImagePickerComponentsHolder.videoModule
     private val stateObs = LiveDataObservableState(
         ImagePickerState(isLoading = true),
         usePostValue = true
@@ -97,7 +96,7 @@ internal class ImagePickerPresenter(
 
     fun captureVideo(fragment: Fragment, config: BaseConfig, requestCode: Int) {
         val context = fragment.requireContext().applicationContext
-        val intent = videoModule.getVideoIntent(fragment.requireContext(), config)
+        val intent = cameraModule.getVideoCameraIntent(fragment.requireContext(), config)
         if (intent == null) {
             Toast.makeText(
                 context,

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/CameraModule.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/CameraModule.kt
@@ -9,6 +9,7 @@ typealias OnImageReadyListener = (List<Image>?) -> Unit
 
 interface CameraModule {
     fun getCameraIntent(context: Context, config: BaseConfig): Intent?
+    fun getVideoIntent(context: Context, config: BaseConfig): Intent?
     fun getImage(context: Context, intent: Intent?, imageReadyListener: OnImageReadyListener)
     fun removeImage(context: Context)
 }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/CameraModule.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/CameraModule.kt
@@ -9,7 +9,7 @@ typealias OnImageReadyListener = (List<Image>?) -> Unit
 
 interface CameraModule {
     fun getCameraIntent(context: Context, config: BaseConfig): Intent?
-    fun getVideoIntent(context: Context, config: BaseConfig): Intent?
+    fun getVideoCameraIntent(context: Context, config: BaseConfig): Intent?
     fun getImage(context: Context, intent: Intent?, imageReadyListener: OnImageReadyListener)
     fun removeImage(context: Context)
 }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/DefaultCameraModule.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/DefaultCameraModule.kt
@@ -35,7 +35,7 @@ class DefaultCameraModule : CameraModule {
         return intent
     }
 
-    override fun getVideoIntent(context: Context, config: BaseConfig): Intent? {
+    override fun getVideoCameraIntent(context: Context, config: BaseConfig): Intent? {
         prepareForNewIntent()
 
         val intent = Intent(MediaStore.ACTION_VIDEO_CAPTURE)

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/DefaultCameraModule.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/camera/DefaultCameraModule.kt
@@ -35,6 +35,22 @@ class DefaultCameraModule : CameraModule {
         return intent
     }
 
+    override fun getVideoIntent(context: Context, config: BaseConfig): Intent? {
+        prepareForNewIntent()
+
+        val intent = Intent(MediaStore.ACTION_VIDEO_CAPTURE)
+        val imageFile = ImagePickerUtils.createVideoFile(config.savePath, context)
+
+        if (config.isSaveVideo && imageFile != null) {
+            val appContext = context.applicationContext
+            val uri = createVideoUri(appContext, imageFile)
+            intent.putExtra(MediaStore.EXTRA_OUTPUT, uri)
+            ImagePickerUtils.grantAppPermission(context, intent, uri)
+            currentUri = uri.toString()
+        }
+        return intent
+    }
+
     private fun prepareForNewIntent() {
         currentImagePath = null
         currentUri = null
@@ -53,6 +69,21 @@ class DefaultCameraModule : CameraModule {
             return appContext.contentResolver.insert(collection, values)
         }
         return UriUtils.uriForFile(appContext, imageFile)
+    }
+
+    private fun createVideoUri(appContext: Context, videoFile: File): Uri? {
+        currentImagePath = "file:" + videoFile.absolutePath
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+
+            val values = ContentValues().apply {
+                put(MediaStore.Video.Media.DISPLAY_NAME, videoFile.name)
+                put(MediaStore.Video.Media.MIME_TYPE, "video/mp4")
+            }
+            val collection =
+                MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+            return appContext.contentResolver.insert(collection, values)
+        }
+        return UriUtils.uriForFile(appContext, videoFile)
     }
 
     override fun getImage(

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/cameraonly/CameraOnlyConfig.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/cameraonly/CameraOnlyConfig.kt
@@ -10,5 +10,6 @@ import kotlinx.android.parcel.Parcelize
 class CameraOnlyConfig(
     override var savePath: ImagePickerSavePath = ImagePickerSavePath.DEFAULT,
     override var returnMode: ReturnMode = ReturnMode.ALL,
-    override var isSaveImage: Boolean = true
+    override var isSaveImage: Boolean = true,
+    override var isSaveVideo: Boolean = true
 ) : BaseConfig(), Parcelable

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/features/common/BaseConfig.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/features/common/BaseConfig.kt
@@ -7,4 +7,5 @@ abstract class BaseConfig {
     abstract var savePath: ImagePickerSavePath
     abstract var returnMode: ReturnMode
     abstract var isSaveImage: Boolean
+    abstract var isSaveVideo: Boolean
 }

--- a/imagepicker/src/main/java/com/esafirm/imagepicker/helper/ImagePickerUtils.kt
+++ b/imagepicker/src/main/java/com/esafirm/imagepicker/helper/ImagePickerUtils.kt
@@ -48,6 +48,27 @@ object ImagePickerUtils {
         return mediaStorageDir
     }
 
+    private fun createFileInDirectoryVideo(savePath: ImagePickerSavePath, context: Context): File? {
+        val path = savePath.path
+        val mediaStorageDir: File = if (savePath.isRelative) {
+            val parent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                context.getExternalFilesDir(Environment.DIRECTORY_MOVIES)
+            } else {
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES)
+            }
+            File(parent, path)
+        } else {
+            File(path)
+        }
+        if (!mediaStorageDir.exists()) {
+            if (!mediaStorageDir.mkdirs()) {
+                d("Oops! Failed create $path")
+                return null
+            }
+        }
+        return mediaStorageDir
+    }
+
     fun createImageFile(savePath: ImagePickerSavePath, context: Context): File? {
         val mediaStorageDir = createFileInDirectory(savePath, context) ?: return null
 
@@ -58,6 +79,18 @@ object ImagePickerUtils {
         while (result.exists()) {
             counter++
             result = File(mediaStorageDir, "IMG_$timeStamp($counter).jpg")
+        }
+        return result
+    }
+
+    fun createVideoFile(savePath: ImagePickerSavePath, context: Context): File? {
+        val mediaStorageDir = createFileInDirectoryVideo(savePath, context) ?: return null
+        val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.getDefault()).format(Date())
+        var result = File(mediaStorageDir, "VID_$timeStamp.mp4")
+        var counter = 0
+        while (result.exists()) {
+            counter++
+            result = File(mediaStorageDir, "VID_$timeStamp($counter).mp4")
         }
         return result
     }

--- a/imagepicker/src/main/res/drawable/ef_video_placeholder.xml
+++ b/imagepicker/src/main/res/drawable/ef_video_placeholder.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF"
+    android:alpha="1.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M17,10.5V7c0,-0.55 -0.45,-1 -1,-1H4c-0.55,0 -1,0.45 -1,1v10c0,0.55 0.45,1 1,1h12c0.55,0 1,-0.45 1,-1v-3.5l4,4v-11l-4,4z"/>
+</vector>

--- a/imagepicker/src/main/res/menu/ef_image_picker_menu_main.xml
+++ b/imagepicker/src/main/res/menu/ef_image_picker_menu_main.xml
@@ -10,6 +10,12 @@
         tools:ignore="AlwaysShowAction" />
 
     <item
+        android:id="@+id/menu_video"
+        android:icon="@drawable/ef_video_placeholder"
+        android:title="@string/ef_video"
+        app:showAsAction="always"/>
+
+    <item
         android:id="@+id/menu_done"
         android:title="@string/ef_done"
         app:showAsAction="always" />

--- a/imagepicker/src/main/res/values-ar/strings.xml
+++ b/imagepicker/src/main/res/values-ar/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">وافق</string>
     <string name="ef_done">انهي</string>
     <string name="ef_camera">كاميرا</string>
+    <string name="ef_video">فيديو</string>
 
     <string name="ef_title_folder">دليل</string>
     <string name="ef_title_select_image">أنقر لإختيار الصور</string>

--- a/imagepicker/src/main/res/values-ar/strings.xml
+++ b/imagepicker/src/main/res/values-ar/strings.xml
@@ -15,6 +15,7 @@
     <string name="ef_selected_with_limit">إخترت %1$d/%2$d</string>
 
     <string name="ef_error_create_image_file">حدث خطأ في تسجيل الصوره</string>
+    <string name="ef_error_create_video_file">فشل إنشاء ملف الفيديو</string>
     <string name="ef_error_no_camera">لا يوجد كاميرا</string>
     <string name="ef_error_null_cursor">عذراً، هناك خطأ ما!</string>
 

--- a/imagepicker/src/main/res/values-ca/strings.xml
+++ b/imagepicker/src/main/res/values-ca/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">OK</string>
     <string name="ef_done">FET</string>
     <string name="ef_camera">CÀMERA</string>
+    <string name="ef_video">VÍDEO</string>
 
     <string name="ef_title_folder">Carpeta</string>
     <string name="ef_title_select_image">Toqueu per seleccionar imatges</string>

--- a/imagepicker/src/main/res/values-ca/strings.xml
+++ b/imagepicker/src/main/res/values-ca/strings.xml
@@ -15,6 +15,8 @@
     <string name="ef_selected_with_limit">%1$d/%2$d seleccionades</string>
 
     <string name="ef_error_create_image_file">Error al crear el fitxer d\'imatge</string>
+    <string name="ef_error_create_video_file">No s\'ha pogut crear el fitxer de vídeo</string>
+
     <string name="ef_error_no_camera">No s\'ha trobat cap càmera</string>
     <string name="ef_error_null_cursor">Oops, alguna cosa no ha anat bé!</string>
 

--- a/imagepicker/src/main/res/values-da/strings.xml
+++ b/imagepicker/src/main/res/values-da/strings.xml
@@ -15,6 +15,8 @@
     <string name="ef_selected_with_limit">%1$d/%2$d valgt</string>
 
     <string name="ef_error_create_image_file">Fejl, kunne ikke oprette billedfilen</string>
+    <string name="ef_error_create_video_file">Kunne ikke oprette videofil</string>
+
     <string name="ef_error_no_camera">Kamera blev ikke fundet</string>
     <string name="ef_error_null_cursor">Beklager, der er sket en fejl!</string>
 

--- a/imagepicker/src/main/res/values-da/strings.xml
+++ b/imagepicker/src/main/res/values-da/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">Ok</string>
     <string name="ef_done">Færdig</string>
     <string name="ef_camera">Kamera</string>
+    <string name="ef_video">VIDEO</string>
 
     <string name="ef_title_folder">Mappe</string>
     <string name="ef_title_select_image">Tryk for at vælge billeder</string>

--- a/imagepicker/src/main/res/values-de/strings.xml
+++ b/imagepicker/src/main/res/values-de/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">OK</string>
     <string name="ef_done">FERTIG</string>
     <string name="ef_camera">KAMERA</string>
+    <string name="ef_video">VIDEO</string>
 
     <string name="ef_title_folder">Verzeichnis</string>
     <string name="ef_title_select_image">Tippen um Bilder auszuwählen</string>

--- a/imagepicker/src/main/res/values-de/strings.xml
+++ b/imagepicker/src/main/res/values-de/strings.xml
@@ -15,6 +15,7 @@
     <string name="ef_selected_with_limit">%1$d/%2$d ausgewählt</string>
 
     <string name="ef_error_create_image_file">Fehler beim Erstellen der Bilddatei</string>
+    <string name="ef_error_create_video_file">Videodatei konnte nicht erstellt werden</string>
     <string name="ef_error_no_camera">Keine Kamera gefunden</string>
     <string name="ef_error_null_cursor">Ups, da ist was schiefgegangen!</string>
 

--- a/imagepicker/src/main/res/values-es-rES/strings.xml
+++ b/imagepicker/src/main/res/values-es-rES/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">OK</string>
     <string name="ef_done">HECHO</string>
     <string name="ef_camera">CÁMARA</string>
+    <string name="ef_video">VIDEO</string>
 
     <string name="ef_title_folder">Carpeta</string>
     <string name="ef_title_select_image">Toque para seleccionar imágenes</string>

--- a/imagepicker/src/main/res/values-es-rES/strings.xml
+++ b/imagepicker/src/main/res/values-es-rES/strings.xml
@@ -15,6 +15,7 @@
     <string name="ef_selected_with_limit">%1$d/%2$d seleccionadas</string>
 
     <string name="ef_error_create_image_file">Error al crear el fichero de imágen</string>
+    <string name="ef_error_create_video_file">No se pudo crear el archivo de video</string>
     <string name="ef_error_no_camera">No se encontró la cámara</string>
     <string name="ef_error_null_cursor">Oops, algo ha ido mal!</string>
 

--- a/imagepicker/src/main/res/values-fr/strings.xml
+++ b/imagepicker/src/main/res/values-fr/strings.xml
@@ -15,6 +15,7 @@
     <string name="ef_selected_with_limit">%1$d/%2$d sélectionnées</string>
 
     <string name="ef_error_create_image_file">Impossible de créer le fichier photo</string>
+    <string name="ef_error_create_video_file">Échec de la création du fichier vidéo</string>
     <string name="ef_error_no_camera">Aucune caméra détectée</string>
     <string name="ef_error_null_cursor">Oups, quelque chose s\'est mal déroulé!</string>
 

--- a/imagepicker/src/main/res/values-fr/strings.xml
+++ b/imagepicker/src/main/res/values-fr/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">OK</string>
     <string name="ef_done">TERMINER</string>
     <string name="ef_camera">CAMERA</string>
+    <string name="ef_video">VIDÉO</string>
 
     <string name="ef_title_folder">Dossier</string>
     <string name="ef_title_select_image">Toucher pour sélectionner des images</string>

--- a/imagepicker/src/main/res/values-in/strings.xml
+++ b/imagepicker/src/main/res/values-in/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">OK</string>
     <string name="ef_done">SELESAI</string>
     <string name="ef_camera">KAMERA</string>
+    <string name="ef_video">VIDEO</string>
 
     <string name="ef_title_folder">Folder</string>
     <string name="ef_title_select_image">Ketuk untuk memilih gambar</string>

--- a/imagepicker/src/main/res/values-in/strings.xml
+++ b/imagepicker/src/main/res/values-in/strings.xml
@@ -15,6 +15,7 @@
     <string name="ef_selected_with_limit">%1$d/%2$d terpilih</string>
 
     <string name="ef_error_create_image_file">Gagal membuat berkas gambar</string>
+    <string name="ef_error_create_video_file">Gagal membuat file video</string>
     <string name="ef_error_no_camera">Kamera tidak ditemukan</string>
     <string name="ef_error_null_cursor">Ups, ada yang tidak beres!</string>
 

--- a/imagepicker/src/main/res/values-it/strings.xml
+++ b/imagepicker/src/main/res/values-it/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">OK</string>
     <string name="ef_done">FATTO</string>
     <string name="ef_camera">CAMERA</string>
+    <string name="ef_video">VIDEO</string>
 
     <string name="ef_title_folder">Cartella</string>
     <string name="ef_title_select_image">Premi per selezionare l\'immagine</string>

--- a/imagepicker/src/main/res/values-it/strings.xml
+++ b/imagepicker/src/main/res/values-it/strings.xml
@@ -14,6 +14,7 @@
     <string name="ef_selected_with_limit">%1$d/%2$d selezionate</string>
 
     <string name="ef_error_create_image_file">Si è verificato un problema nella creazione dell\'immagine</string>
+    <string name="ef_error_create_video_file">Impossibile creare il file video</string>
     <string name="ef_error_no_camera">Nessuna fotocamera trovata</string>
     <string name="ef_error_null_cursor">Oops, qualcosa è andato storto!</string>
 

--- a/imagepicker/src/main/res/values-ja/strings.xml
+++ b/imagepicker/src/main/res/values-ja/strings.xml
@@ -4,6 +4,7 @@
     <string name="ef_ok">OK</string>
     <string name="ef_done">完了</string>
     <string name="ef_camera">カメラ</string>
+    <string name="ef_video">ビデオ</string>
 
     <string name="ef_title_folder">フォルダ</string>
     <string name="ef_title_select_image">画像を選択</string>

--- a/imagepicker/src/main/res/values-ja/strings.xml
+++ b/imagepicker/src/main/res/values-ja/strings.xml
@@ -17,6 +17,7 @@
     <string name="ef_error_null_cursor">エラーが発生しました</string>
 
     <string name="ef_msg_empty_images">画像が見つかりません</string>
+    <string name="ef_error_create_video_file">動画ファイルの作成に失敗しました</string>
     <string name="ef_msg_no_write_external_permission">端末のファイルへのアクセスを許可してください</string>
     <string name="ef_msg_no_camera_permission">端末のカメラへのアクセスを許可してください</string>
     <string name="ef_msg_limit_images">選択できる画像の上限です</string>

--- a/imagepicker/src/main/res/values-ko/strings.xml
+++ b/imagepicker/src/main/res/values-ko/strings.xml
@@ -15,6 +15,7 @@
     <string name="ef_selected_with_limit">%1$d/%2$d 선택됨</string>
 
     <string name="ef_error_create_image_file">이미지 생성에 실패하였습니다.</string>
+    <string name="ef_error_create_video_file">동영상 파일 생성 실패</string>
     <string name="ef_error_no_camera">카메라를 찾을 수 없습니다.</string>
     <string name="ef_error_null_cursor">알 수 없는 오류가 발생하였습니다.</string>
 

--- a/imagepicker/src/main/res/values-ko/strings.xml
+++ b/imagepicker/src/main/res/values-ko/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">확인</string>
     <string name="ef_done">완료</string>
     <string name="ef_camera">카메라</string>
+    <string name="ef_video">동영상</string>
 
     <string name="ef_title_folder">사진첩</string>
     <string name="ef_title_select_image">이미지를 선택하세요</string>

--- a/imagepicker/src/main/res/values-pt-rBR/strings.xml
+++ b/imagepicker/src/main/res/values-pt-rBR/strings.xml
@@ -15,6 +15,7 @@
     <string name="ef_selected_with_limit">%1$d/%2$d selecionadas</string>
 
     <string name="ef_error_create_image_file">Erro ao criar arquivo de imagem</string>
+    <string name="ef_error_create_video_file">Falha ao criar arquivo de vídeo</string>
     <string name="ef_error_no_camera">Câmera não encontrada</string>
     <string name="ef_error_null_cursor">Ops, algo deu errado!</string>
 

--- a/imagepicker/src/main/res/values-pt-rBR/strings.xml
+++ b/imagepicker/src/main/res/values-pt-rBR/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">OK</string>
     <string name="ef_done">FEITO</string>
     <string name="ef_camera">CAMERA</string>
+    <string name="ef_video">VÍDEO</string>
 
     <string name="ef_title_folder">Pasta</string>
     <string name="ef_title_select_image">Toque para selecionar as imagens</string>

--- a/imagepicker/src/main/res/values-ro/strings.xml
+++ b/imagepicker/src/main/res/values-ro/strings.xml
@@ -14,6 +14,7 @@
     <string name="ef_selected_with_limit">%1$d/%2$d selectate</string>
 
     <string name="ef_error_create_image_file">Nu am putut crea imaginea</string>
+    <string name="ef_error_create_video_file">Nu s-a putut crea fișierul video</string>
     <string name="ef_error_no_camera">Camera foto nu a fost găsită</string>
     <string name="ef_error_null_cursor">Hopa, ceva a mers prost!</string>
 

--- a/imagepicker/src/main/res/values-ro/strings.xml
+++ b/imagepicker/src/main/res/values-ro/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">OK</string>
     <string name="ef_done">TERMINAT</string>
     <string name="ef_camera">CAMERA</string>
+    <string name="ef_video">VIDEO</string>
 
     <string name="ef_title_folder">Fișier</string>
     <string name="ef_title_select_image">Atingeți pentru a selecta imagini</string>

--- a/imagepicker/src/main/res/values-ru/strings.xml
+++ b/imagepicker/src/main/res/values-ru/strings.xml
@@ -12,6 +12,7 @@
     <string name="ef_selected">%d выбрано</string>
     <string name="ef_selected_with_limit">%1$d/%2$d выбрано</string>
     <string name="ef_error_create_image_file">Не удалось создать файл</string>
+    <string name="ef_error_create_video_file">Не удалось создать видеофайл</string>
     <string name="ef_error_no_camera">Камера недоступна</string>
     <string name="ef_error_null_cursor">Ой! Что-то пошло не так!</string>
     <string name="ef_msg_empty_images">Изображений не найдено</string>

--- a/imagepicker/src/main/res/values-ru/strings.xml
+++ b/imagepicker/src/main/res/values-ru/strings.xml
@@ -4,6 +4,8 @@
     <string name="ef_ok">ОК</string>
     <string name="ef_done">ГОТОВО</string>
     <string name="ef_camera">КАМЕРА</string>
+    <string name="ef_video">ВИДЕО</string>
+
     <string name="ef_title_folder">Папка</string>
     <string name="ef_title_select_image">Коснитесь, чтобы выбрать</string>
     <string name="ef_ltitle_permission_denied">Доступ запрещён</string>

--- a/imagepicker/src/main/res/values-sv-rSE/strings.xml
+++ b/imagepicker/src/main/res/values-sv-rSE/strings.xml
@@ -15,6 +15,8 @@
     <string name="ef_selected_with_limit">%1$d/%2$d valda</string>
 
     <string name="ef_error_create_image_file">Misslyckades att skapa bildfil</string>
+    <string name="ef_error_create_video_file">Det gick inte att skapa videofil</string>
+
     <string name="ef_error_no_camera">Ingen kamera hittades</string>
     <string name="ef_error_null_cursor">Hopsan! Något gick fel!</string>
 

--- a/imagepicker/src/main/res/values-sv-rSE/strings.xml
+++ b/imagepicker/src/main/res/values-sv-rSE/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">OK</string>
     <string name="ef_done">KLAR</string>
     <string name="ef_camera">KAMERA</string>
+    <string name="ef_video">VIDEO</string>
 
     <string name="ef_title_folder">Mapp</string>
     <string name="ef_title_select_image">Tryck för att välja bilder</string>

--- a/imagepicker/src/main/res/values-tr/strings.xml
+++ b/imagepicker/src/main/res/values-tr/strings.xml
@@ -3,6 +3,8 @@
     <string name="ef_ok">TAMAM</string>
     <string name="ef_done">BİTTİ</string>
     <string name="ef_camera">KAMERA</string>
+    <string name="ef_video">VİDEO</string>
+
     <string name="ef_permission_write_external_rationale">Görüntüleri seçmek için harici depolama alanına erişime izin ver</string>
 
     <string name="ef_title_folder">Klasör</string>

--- a/imagepicker/src/main/res/values-tr/strings.xml
+++ b/imagepicker/src/main/res/values-tr/strings.xml
@@ -9,6 +9,7 @@
 
     <string name="ef_title_folder">Klasör</string>
     <string name="ef_title_select_image">Resimleri seçmek için hafifçe dokunun</string>
+    <string name="ef_error_create_video_file">Video dosyası oluşturulamadı</string>
     <string name="ef_ltitle_permission_denied">İzin reddedildi</string>
 
     <string name="ef_selected">%d seçili</string>

--- a/imagepicker/src/main/res/values-uk/strings.xml
+++ b/imagepicker/src/main/res/values-uk/strings.xml
@@ -8,6 +8,7 @@
 
     <string name="ef_title_folder">Папка</string>
     <string name="ef_title_select_image">Торкніться, щоб обрати</string>
+    <string name="ef_error_create_video_file">Не вдалося створити відеофайл</string>
     <string name="ef_ltitle_permission_denied">Доступ заборонено</string>
     <string name="ef_selected">%d обрано</string>
     <string name="ef_selected_with_limit">%1$d/%2$d обрано</string>

--- a/imagepicker/src/main/res/values-uk/strings.xml
+++ b/imagepicker/src/main/res/values-uk/strings.xml
@@ -4,6 +4,8 @@
     <string name="ef_ok">ОК</string>
     <string name="ef_done">ГОТОВО</string>
     <string name="ef_camera">КАМЕРА</string>
+    <string name="ef_video">ВІДЕО</string>
+
     <string name="ef_title_folder">Папка</string>
     <string name="ef_title_select_image">Торкніться, щоб обрати</string>
     <string name="ef_ltitle_permission_denied">Доступ заборонено</string>

--- a/imagepicker/src/main/res/values-zh-rCN/strings.xml
+++ b/imagepicker/src/main/res/values-zh-rCN/strings.xml
@@ -4,6 +4,7 @@
     <string name="ef_ok">好</string>
     <string name="ef_done">完成</string>
     <string name="ef_camera">相机</string>
+    <string name="ef_video">视频</string>
 
     <string name="ef_title_folder">文件夹</string>
     <string name="ef_title_select_image">选择照片</string>

--- a/imagepicker/src/main/res/values-zh-rCN/strings.xml
+++ b/imagepicker/src/main/res/values-zh-rCN/strings.xml
@@ -13,6 +13,8 @@
     <string name="ef_selected_with_limit">已选择 %1$d/%2$d</string>
 
     <string name="ef_error_create_image_file">建立照片文件失败</string>
+    <string name="ef_error_create_video_file">创建视频文件失败</string>
+
     <string name="ef_error_no_camera">找不到相机</string>
     <string name="ef_error_null_cursor">啊哦，发生错误！</string>
 

--- a/imagepicker/src/main/res/values-zh-rTW/strings.xml
+++ b/imagepicker/src/main/res/values-zh-rTW/strings.xml
@@ -13,6 +13,8 @@
     <string name="ef_selected_with_limit">已選擇 %1$d/%2$d</string>
 
     <string name="ef_error_create_image_file">建立相片檔案失敗</string>
+    <string name="ef_error_create_video_file">創建視頻文件失敗</string>
+
     <string name="ef_error_no_camera">找不到相機</string>
     <string name="ef_error_null_cursor">噢，發生問題</string>
 

--- a/imagepicker/src/main/res/values-zh-rTW/strings.xml
+++ b/imagepicker/src/main/res/values-zh-rTW/strings.xml
@@ -4,6 +4,7 @@
     <string name="ef_ok">好</string>
     <string name="ef_done">完成</string>
     <string name="ef_camera">相機</string>
+    <string name="ef_video">視頻</string>
 
     <string name="ef_title_folder">檔案夹</string>
     <string name="ef_title_select_image">選擇相片</string>

--- a/imagepicker/src/main/res/values/strings.xml
+++ b/imagepicker/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="ef_ok">OK</string>
     <string name="ef_done">DONE</string>
     <string name="ef_camera">CAMERA</string>
+    <string name="ef_video">VIDEO</string>
 
     <string name="ef_title_folder">Folder</string>
     <string name="ef_title_select_image">Tap to select images</string>

--- a/imagepicker/src/main/res/values/strings.xml
+++ b/imagepicker/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="ef_selected_with_limit">%1$d/%2$d selected</string>
 
     <string name="ef_error_create_image_file">Failed to create image file</string>
+    <string name="ef_error_create_video_file">Failed to create video file</string>
     <string name="ef_error_no_camera">No camera found</string>
     <string name="ef_error_null_cursor">Oops, something went wrong!</string>
 

--- a/sample/src/main/java/com/esafirm/sample/CustomUIActivity.kt
+++ b/sample/src/main/java/com/esafirm/sample/CustomUIActivity.kt
@@ -87,14 +87,13 @@ class CustomUIActivity : AppCompatActivity() {
     }
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
-        if (config == null) super.onPrepareOptionsMenu(menu)
         val menuCamera = menu.findItem(com.esafirm.imagepicker.R.id.menu_camera)
         if (menuCamera != null) {
             menuCamera.isVisible = config?.isShowCamera == true && config?.isOnlyVideo == false
         }
         val menuVideo = menu.findItem(com.esafirm.imagepicker.R.id.menu_video)
         if (menuVideo != null) {
-            menuVideo.isVisible = config!!.isShowVideo
+            menuVideo.isVisible = config?.isShowVideoCamera == true
         }
         val menuDone = menu.findItem(com.esafirm.imagepicker.R.id.menu_done)
         if (menuDone != null) {

--- a/sample/src/main/java/com/esafirm/sample/CustomUIActivity.kt
+++ b/sample/src/main/java/com/esafirm/sample/CustomUIActivity.kt
@@ -87,11 +87,14 @@ class CustomUIActivity : AppCompatActivity() {
     }
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
+        if (config == null) super.onPrepareOptionsMenu(menu)
         val menuCamera = menu.findItem(com.esafirm.imagepicker.R.id.menu_camera)
         if (menuCamera != null) {
-            if (config != null) {
-                menuCamera.isVisible = config!!.isShowCamera
-            }
+            menuCamera.isVisible = config?.isShowCamera == true && config?.isOnlyVideo == false
+        }
+        val menuVideo = menu.findItem(com.esafirm.imagepicker.R.id.menu_video)
+        if (menuVideo != null) {
+            menuVideo.isVisible = config!!.isShowVideo
         }
         val menuDone = menu.findItem(com.esafirm.imagepicker.R.id.menu_done)
         if (menuDone != null) {
@@ -116,6 +119,10 @@ class CustomUIActivity : AppCompatActivity() {
         }
         if (id == com.esafirm.imagepicker.R.id.menu_camera) {
             imagePickerFragment.captureImage()
+            return true
+        }
+        if (id == com.esafirm.imagepicker.R.id.menu_video) {
+            imagePickerFragment.captureVideo()
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/sample/src/main/java/com/esafirm/sample/MainActivity.kt
+++ b/sample/src/main/java/com/esafirm/sample/MainActivity.kt
@@ -85,6 +85,7 @@ class MainActivity : AppCompatActivity() {
             showDoneButtonAlways = true // Show done button always or not
             limit = 10 // max images can be selected (99 by default)
             isShowCamera = true // show camera or not (true by default)
+            isShowVideo = true // show video or not (true by default)
             savePath = ImagePickerSavePath("Camera") // captured image directory name ("Camera" folder by default)
             savePath = ImagePickerSavePath(Environment.getExternalStorageDirectory().path, isRelative = false) // can be a full path
 

--- a/sample/src/main/java/com/esafirm/sample/MainActivity.kt
+++ b/sample/src/main/java/com/esafirm/sample/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : AppCompatActivity() {
             showDoneButtonAlways = true // Show done button always or not
             limit = 10 // max images can be selected (99 by default)
             isShowCamera = true // show camera or not (true by default)
-            isShowVideo = true // show video or not (true by default)
+            isShowVideoCamera = true // show video or not (true by default)
             savePath = ImagePickerSavePath("Camera") // captured image directory name ("Camera" folder by default)
             savePath = ImagePickerSavePath(Environment.getExternalStorageDirectory().path, isRelative = false) // can be a full path
 


### PR DESCRIPTION
### Issue:
When `OnlyVideo` is enabled the camera icon opens in the camera mode instead of the video mode

### Description and steps:
When `OnlyVideo` is enabled and the user clicks on the camera icon, it opens the camera instead of the video.
Steps:
1. Enable "Only Video" mode
2. Click on any video picker functionality
3. Click on the camera icon
4. The picture mode is displayed instead of the video mode

### Expected behavior:
When `OnlyVideo` is enabled and the user clicks on the camera icon, it opens the camera instead of the video.

### Issue recording:
https://user-images.githubusercontent.com/20037228/196473466-53e77776-e33c-4a48-83e6-1ef36d4ed0ec.mp4

### Fixed issue recording:
https://user-images.githubusercontent.com/20037228/196473491-db29dc0f-8006-4c4a-b4e5-455702ab9ce1.mp4

Please let me know if you have any feedback.
Thank you!

Close #260 
