### PR TITLE
Fix/handle scoped storage again

### DIFF
--- a/imagepicker/src/main/AndroidManifest.xml
+++ b/imagepicker/src/main/AndroidManifest.xml
@@ -3,8 +3,13 @@
     package="com.esafirm.imagepicker">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
+
+    <!--  Tiramisu and above  -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
     <application>
         <activity

--- a/sample/src/androidTest/java/com/esafirm/sample/CameraOnPickerTest.kt
+++ b/sample/src/androidTest/java/com/esafirm/sample/CameraOnPickerTest.kt
@@ -12,6 +12,7 @@ import androidx.test.rule.GrantPermissionRule
 import com.adevinta.android.barista.intents.BaristaIntents.mockAndroidCamera
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaMenuClickInteractions
+import com.esafirm.sample.utils.Rules
 import com.esafirm.sample.utils.ViewAsserts
 import com.esafirm.sample.utils.Views
 import org.junit.Rule
@@ -28,9 +29,7 @@ class CameraOnPickerTest {
 
     @Rule
     @JvmField
-    val grantPermissionRule = GrantPermissionRule.grant(
-        "android.permission.WRITE_EXTERNAL_STORAGE"
-    )
+    val grantPermissionRule = Rules.AIP_PERMISSIONS
 
     private fun callCamera() {
         Intents.init()

--- a/sample/src/androidTest/java/com/esafirm/sample/CameraOnlyTest.kt
+++ b/sample/src/androidTest/java/com/esafirm/sample/CameraOnlyTest.kt
@@ -13,11 +13,11 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.rule.GrantPermissionRule
 import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.adevinta.android.barista.intents.BaristaIntents.mockAndroidCamera
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.esafirm.sample.matchers.hasDrawable
+import com.esafirm.sample.utils.Rules
 import com.esafirm.sample.utils.ViewAsserts
 import com.esafirm.sample.utils.Views
 import org.junit.Rule
@@ -34,9 +34,7 @@ class CameraOnlyTest {
 
     @Rule
     @JvmField
-    var grantPermissionRule = GrantPermissionRule.grant(
-        "android.permission.WRITE_EXTERNAL_STORAGE"
-    )
+    val grantPermissionRule = Rules.AIP_PERMISSIONS
 
     private fun runCameraOnly() {
         Intents.init()

--- a/sample/src/androidTest/java/com/esafirm/sample/CustomUiTest.kt
+++ b/sample/src/androidTest/java/com/esafirm/sample/CustomUiTest.kt
@@ -7,8 +7,8 @@ import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.rule.GrantPermissionRule
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
+import com.esafirm.sample.utils.Rules
 import com.esafirm.sample.utils.ViewAsserts
 import com.esafirm.sample.utils.Views
 import org.junit.Rule
@@ -25,9 +25,7 @@ class CustomUiTest {
 
     @Rule
     @JvmField
-    var grantPermissionRule = GrantPermissionRule.grant(
-        "android.permission.WRITE_EXTERNAL_STORAGE"
-    )
+    val grantPermissionRule = Rules.AIP_PERMISSIONS
 
     @Test
     fun cameraOnlyTestTwo() {

--- a/sample/src/androidTest/java/com/esafirm/sample/PickImageFolderMode.kt
+++ b/sample/src/androidTest/java/com/esafirm/sample/PickImageFolderMode.kt
@@ -7,8 +7,8 @@ import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.rule.GrantPermissionRule
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
+import com.esafirm.sample.utils.Rules
 import com.esafirm.sample.utils.ViewAsserts
 import com.esafirm.sample.utils.Views
 import org.junit.Rule
@@ -25,7 +25,7 @@ class PickImageFolderMode {
 
     @Rule
     @JvmField
-    var mGrantPermissionRule = GrantPermissionRule.grant("android.permission.WRITE_EXTERNAL_STORAGE")
+    val grantPermissionRule = Rules.AIP_PERMISSIONS
 
     @Test
     fun pickImage() {

--- a/sample/src/androidTest/java/com/esafirm/sample/PickImageFragmentTest.kt
+++ b/sample/src/androidTest/java/com/esafirm/sample/PickImageFragmentTest.kt
@@ -6,10 +6,10 @@ import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.rule.GrantPermissionRule
 import com.adevinta.android.barista.assertion.BaristaImageViewAssertions.assertHasAnyDrawable
 import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
+import com.esafirm.sample.utils.Rules
 import com.esafirm.sample.utils.Views
 import org.junit.Rule
 import org.junit.Test
@@ -25,8 +25,7 @@ class PickImageFragmentTest {
 
     @Rule
     @JvmField
-    val mGrantPermissionRule =
-        GrantPermissionRule.grant("android.permission.WRITE_EXTERNAL_STORAGE")
+    val grantPermissionRule = Rules.AIP_PERMISSIONS
 
     @Test
     fun pickImage() {

--- a/sample/src/androidTest/java/com/esafirm/sample/PickImageSingleTest.kt
+++ b/sample/src/androidTest/java/com/esafirm/sample/PickImageSingleTest.kt
@@ -7,8 +7,8 @@ import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.rule.GrantPermissionRule
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
+import com.esafirm.sample.utils.Rules
 import com.esafirm.sample.utils.ViewAsserts
 import com.esafirm.sample.utils.Views
 import org.junit.Rule
@@ -25,7 +25,7 @@ class PickImageSingleTest {
 
     @Rule
     @JvmField
-    var mGrantPermissionRule = GrantPermissionRule.grant("android.permission.WRITE_EXTERNAL_STORAGE")
+    val grantPermissionRule = Rules.AIP_PERMISSIONS
 
     @Test
     fun pickImage() {

--- a/sample/src/androidTest/java/com/esafirm/sample/PickImageTest.kt
+++ b/sample/src/androidTest/java/com/esafirm/sample/PickImageTest.kt
@@ -13,8 +13,8 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.rule.GrantPermissionRule
 import com.esafirm.sample.matchers.hasDrawable
+import com.esafirm.sample.utils.Rules
 import com.esafirm.sample.utils.Views
 import org.hamcrest.CoreMatchers.allOf
 import org.junit.Rule
@@ -31,7 +31,7 @@ class PickImageTest {
 
     @Rule
     @JvmField
-    var mGrantPermissionRule = GrantPermissionRule.grant("android.permission.WRITE_EXTERNAL_STORAGE")
+    val grantPermissionRule = Rules.AIP_PERMISSIONS
 
     @Test
     fun pickImage() {

--- a/sample/src/androidTest/java/com/esafirm/sample/utils/Rules.kt
+++ b/sample/src/androidTest/java/com/esafirm/sample/utils/Rules.kt
@@ -1,0 +1,20 @@
+package com.esafirm.sample.utils
+
+import android.os.Build
+import androidx.test.rule.GrantPermissionRule
+
+object Rules {
+    val AIP_PERMISSIONS: GrantPermissionRule by lazy {
+        // Tiramisu
+        if (Build.VERSION.SDK_INT >= 31) {
+            GrantPermissionRule.grant(
+                "android.permission.READ_MEDIA_IMAGES",
+                "android.permission.READ_MEDIA_VIDEO"
+            )
+        } else {
+            GrantPermissionRule.grant(
+                "android.permission.READ_EXTERNAL_STORAGE"
+            )
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/esafirm/android-image-picker/pull/362 for 3.x

Close https://github.com/esafirm/android-image-picker/issues/422, https://github.com/esafirm/android-image-picker/issues/371

Context: https://github.com/esafirm/android-image-picker/pull/362#issuecomment-1321025997

Tested in Android 11 and Tiramisu